### PR TITLE
Mark device tree area on page allocator as reserved

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![allow(dead_code)]
 #![allow(unused_variables)]
+#![feature(ptr_mask)]
 
 pub mod array_vec;
 pub mod big_endian;

--- a/common/src/util.rs
+++ b/common/src/util.rs
@@ -6,3 +6,7 @@ pub const fn align_up(value: usize, alignment: usize) -> usize {
         value + alignment - remainder
     }
 }
+
+pub fn align_down_ptr<T>(ptr: *const T, alignment: usize) -> *const T {
+    ptr.mask(!(alignment - 1))
+}

--- a/kernel/src/memory/heap.rs
+++ b/kernel/src/memory/heap.rs
@@ -310,7 +310,7 @@ mod test {
         unsafe {
             PAGE_ALLOC
                 .lock()
-                .init(&mut *addr_of_mut!(PAGE_ALLOC_MEMORY));
+                .init(&mut *addr_of_mut!(PAGE_ALLOC_MEMORY), &[]);
         }
     }
 


### PR DESCRIPTION
With that we don't need to copy the device tree into a static variable. We can leave it as it is in memory and just never allocate it.

Yes, this possibly wastes memory because we have to reserve the space on a page boundary. However, memory is cheap nowadays and it is preferable to have a simple solution.