### PR TITLE
Speedup heap initialization

### DIFF
--- a/kernel/src/memory/heap.rs
+++ b/kernel/src/memory/heap.rs
@@ -274,25 +274,24 @@ pub fn allocated_size() -> usize {
 
 #[cfg(test)]
 mod test {
-    use core::{
-        alloc::GlobalAlloc,
-        ops::Range,
-        ptr::{addr_of_mut, NonNull},
-    };
-
-    use common::mutex::Mutex;
-
+    use super::{FreeBlock, MutexHeap, PAGE_SIZE};
     use crate::memory::{
         page::Page,
         page_allocator::{MetadataPageAllocator, PageAllocator},
     };
-
-    use super::{FreeBlock, MutexHeap, PAGE_SIZE};
+    use common::mutex::Mutex;
+    use core::{
+        alloc::GlobalAlloc,
+        mem::MaybeUninit,
+        ops::Range,
+        ptr::{addr_of_mut, NonNull},
+    };
 
     const HEAP_PAGES: usize = 8;
     const HEAP_SIZE: usize = (HEAP_PAGES - 1) * PAGE_SIZE;
 
-    static mut PAGE_ALLOC_MEMORY: [u8; PAGE_SIZE * HEAP_PAGES] = [0; PAGE_SIZE * HEAP_PAGES];
+    static mut PAGE_ALLOC_MEMORY: [MaybeUninit<u8>; PAGE_SIZE * HEAP_PAGES] =
+        [const { MaybeUninit::uninit() }; PAGE_SIZE * HEAP_PAGES];
     static PAGE_ALLOC: Mutex<MetadataPageAllocator> = Mutex::new(MetadataPageAllocator::new());
 
     struct TestAllocator;

--- a/kernel/src/memory/mod.rs
+++ b/kernel/src/memory/mod.rs
@@ -1,9 +1,4 @@
-use core::{
-    mem::{transmute, MaybeUninit},
-    ops::Range,
-    ptr::NonNull,
-    slice::from_raw_parts_mut,
-};
+use core::{mem::MaybeUninit, ops::Range, ptr::NonNull, slice::from_raw_parts_mut};
 
 use common::mutex::Mutex;
 
@@ -43,17 +38,7 @@ pub fn init_page_allocator(
     reserved_areas: &[Range<*const u8>],
 ) {
     let memory = unsafe { from_raw_parts_mut(heap_start as *mut MaybeUninit<u8>, heap_size) };
-    // Iterate over all elements which are not inside the reserved areas
-    for elem in memory
-        .iter_mut()
-        .filter(|m| !reserved_areas.iter().any(|r| r.contains(&m.as_ptr())))
-    {
-        elem.write(0);
-    }
-    let initialized_memory = unsafe { transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(memory) };
-    PAGE_ALLOCATOR
-        .lock()
-        .init(initialized_memory, reserved_areas);
+    PAGE_ALLOCATOR.lock().init(memory, reserved_areas);
 }
 
 pub fn used_heap_pages() -> usize {

--- a/kernel/src/memory/page.rs
+++ b/kernel/src/memory/page.rs
@@ -34,7 +34,7 @@ impl core::fmt::Debug for Page {
 }
 
 impl Page {
-    fn zero() -> Self {
+    pub(super) fn zero() -> Self {
         Self([0; PAGE_SIZE])
     }
 }


### PR DESCRIPTION
We don't want to iterate over the reserved areas for each byte of heap initialization. Make it more cleverer and initialize heap after we set the reserved ares.