### PR TITLE
Remove all-targets=false setting

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -1,6 +1,0 @@
-[[language]]
-name = "rust"
-
-[language-server.rust-analyzer.config.check]
-targets = ["riscv64gc-unknown-none-elf"]
-allTargets = false

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,3 +6,7 @@ authors.workspace = true
 version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+test = false
+bench = false

--- a/userspace/Cargo.toml
+++ b/userspace/Cargo.toml
@@ -9,3 +9,46 @@ description.workspace = true
 
 [dependencies]
 common = { path = "../common" }
+
+# Without theese the rust-analyzer would try to build the crate with tests enabled
+# which is not possible in no_std environments. I'm looking for a way where I don't
+# have to specify that individually for every file. But because userspace will
+# change anyways in the future, let's leave like that for now.
+[lib]
+test = false
+bench = false
+
+[[bin]]
+name = "init"
+test = false
+bench = false
+
+[[bin]]
+name = "loop"
+test = false
+bench = false
+
+[[bin]]
+name = "panic"
+test = false
+bench = false
+
+[[bin]]
+name = "prog1"
+test = false
+bench = false
+
+[[bin]]
+name = "prog2"
+test = false
+bench = false
+
+[[bin]]
+name = "udp"
+test = false
+bench = false
+
+[[bin]]
+name = "yash"
+test = false
+bench = false


### PR DESCRIPTION
This setting disallowed the use of rust-analyzer in tests. The downside of this is that we have to specify each userspace binary separately in userspace/Cargo.toml. But let's leave it like that for now...