### PR TITLE
Downgrade compiler back to nightly-2024-11-09

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
     "userspace",
 ]
 default-members = ["kernel"]
-resolver = "3"
+resolver = "2"
 
 [workspace.package]
 description = "Yet another Rust Operating System (YaROS)"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "common"
-edition = "2024"
+edition = "2021"
 description.workspace = true
 authors.workspace = true
 version.workspace = true

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaros"
-edition = "2024"
+edition = "2021"
 version.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-12-04"
+channel = "nightly-2024-11-09"
 targets = ["riscv64gc-unknown-none-elf"]

--- a/userspace/Cargo.toml
+++ b/userspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "userspace"
-edition = "2024"
+edition = "2021"
 version.workspace = true
 authors.workspace = true
 description.workspace = true


### PR DESCRIPTION
The newer versions have a faulty rust-analyzer which does not work well with the Helix editor. The auto completion sometimes changes while cycling through them.

We need to wait until this is fixed either here
https://github.com/helix-editor/helix/issues/12119 or here
https://github.com/rust-lang/rust-analyzer/issues/18547