### PR TITLE
ci: Cache Miri sysroot

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -16,3 +16,7 @@ cargo install just cargo-nextest --locked
 
 # Download dependencies into cache
 just fetch-deps
+
+# Prepare the sysroot for miri such that it is cached as well
+cd /tmp
+cargo +"$TOOLCHAIN" miri test --target riscv64gc-unknown-linux-gnu || true


### PR DESCRIPTION
This will reduce the time of running miri.