### PR TITLE
Using core::ptr::without_provenance_mut to make Miri happy

### DIFF
--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ system-test: build
     cargo nextest run --release --manifest-path system-tests/Cargo.toml --target x86_64-unknown-linux-gnu
 
 miri: build-cargo
-    MIRIFLAGS="-Zmiri-permissive-provenance -Zmiri-env-forward=RUST_BACKTRACE" RUST_BACKTRACE=1 cargo miri test --target riscv64gc-unknown-linux-gnu
+    MIRIFLAGS="-Zmiri-env-forward=RUST_BACKTRACE" RUST_BACKTRACE=1 cargo miri test --target riscv64gc-unknown-linux-gnu
 
 fetch-deps:
     cargo fetch

--- a/kernel/src/processes/process.rs
+++ b/kernel/src/processes/process.rs
@@ -91,7 +91,7 @@ impl Process {
             "Heap",
         );
         self.allocated_pages.push(pages);
-        let ptr = self.free_mmap_address as *mut u8;
+        let ptr = core::ptr::without_provenance_mut(self.free_mmap_address);
         self.free_mmap_address += number_of_pages * PAGE_SIZE;
         ptr
     }


### PR DESCRIPTION
We don't dereference that pointer in the kernel. We pass it to the userspace. Make Miri happy and remove the permissive provenance setting.