### PR TITLE
Rename from YaROS to YaOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "yaros"
+name = "yaos"
 version = "0.1.0"
 dependencies = [
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ default-members = ["kernel"]
 resolver = "2"
 
 [workspace.package]
-description = "Yet another Rust Operating System (YaROS)"
-authors = ["Maurice Hieronymus <yaros@ilovebinary.com>"]
+description = "Yet another Operating System (YaOS)"
+authors = ["Maurice Hieronymus <yaos@ilovebinary.com>"]
 version = "0.1.0"
 
 [profile.release]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "yaros"
+name = "yaos"
 edition = "2021"
 version.workspace = true
 authors.workspace = true

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -59,7 +59,7 @@ extern crate alloc;
 extern "C" fn kernel_init(hart_id: usize, device_tree_pointer: *const ()) {
     QEMU_UART.lock().init();
 
-    info!("Hello World from YaROS!\n");
+    info!("Hello World from YaOS!\n");
     info!("Hart ID: {}", hart_id);
     info!("Device Tree Pointer: {:p}", device_tree_pointer);
 

--- a/qemu_wrapper.sh
+++ b/qemu_wrapper.sh
@@ -20,7 +20,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --log)
-            QEMU_CMD+=" -d guest_errors,cpu_reset,unimp,int -D /tmp/yaros.log"
+            QEMU_CMD+=" -d guest_errors,cpu_reset,unimp,int -D /tmp/yaos.log"
             shift
             ;;
         --net)
@@ -36,7 +36,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --gdb          Let qemu listen on :1234 for gdb connections"
-            echo "  --log          Log qemu events to /tmp/yaros.log"
+            echo "  --log          Log qemu events to /tmp/yaos.log"
             echo "  --capture      Capture network traffic into network.pcap"
             echo "  --net          Enable network card"
             echo "  -h, --help     Show this help message"

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
-# YaROS (Yet another RISC-V Operating System)
-[![ci](https://github.com/hieronymusma/yaros/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/hieronymusma/yaros/actions/workflows/ci.yml)  
+# YaOS (Yet another Operating System)
+[![ci](https://github.com/hieronymusma/yaos/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/hieronymusma/yaos/actions/workflows/ci.yml)  
 This projects makes my dream come true - write my own operating system. I'm doing this mostly for fun, so don't expect a fully-fledged operating system on basis of the RISC-V architecture.
 Exactly like [SerenityOS](https://github.com/SerenityOS/serenity) this project doesn't use third-party runtime dependencies. If third-party dependencies are used, then only for the Build.
 

--- a/system-tests/src/infra/qemu.rs
+++ b/system-tests/src/infra/qemu.rs
@@ -70,7 +70,7 @@ impl QemuInstance {
 
         let mut stdout = ReadAsserter::new(stdout);
 
-        stdout.assert_read_until("Hello World from YaROS!").await;
+        stdout.assert_read_until("Hello World from YaOS!").await;
         stdout.assert_read_until("kernel_init done!").await;
         stdout.assert_read_until("init process started").await;
         stdout

--- a/system-tests/src/tests/basics.rs
+++ b/system-tests/src/tests/basics.rs
@@ -17,22 +17,21 @@ async fn boot_with_network() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn shutdown() -> anyhow::Result<()> {
-    let mut yaros = QemuInstance::start().await?;
+    let mut yaos = QemuInstance::start().await?;
 
-    yaros
-        .run_prog_waiting_for("exit", "shutting down system")
+    yaos.run_prog_waiting_for("exit", "shutting down system")
         .await?;
 
-    assert!(yaros.wait_for_qemu_to_exit().await?.success());
+    assert!(yaos.wait_for_qemu_to_exit().await?.success());
 
     Ok(())
 }
 
 #[tokio::test]
 async fn execute_program() -> anyhow::Result<()> {
-    let mut yaros = QemuInstance::start().await?;
+    let mut yaos = QemuInstance::start().await?;
 
-    let output = yaros.run_prog("prog1").await?;
+    let output = yaos.run_prog("prog1").await?;
 
     assert_eq!(output, "Hello from Prog1\n");
 
@@ -41,14 +40,14 @@ async fn execute_program() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn execute_same_program_twice() -> anyhow::Result<()> {
-    let mut yaros = QemuInstance::start().await?;
+    let mut yaos = QemuInstance::start().await?;
 
     let expected = "Hello from Prog1\n";
 
-    let output = yaros.run_prog("prog1").await?;
+    let output = yaos.run_prog("prog1").await?;
     assert_eq!(output, expected);
 
-    let output = yaros.run_prog("prog1").await?;
+    let output = yaos.run_prog("prog1").await?;
     assert_eq!(output, expected);
 
     Ok(())
@@ -56,12 +55,12 @@ async fn execute_same_program_twice() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn execute_different_programs() -> anyhow::Result<()> {
-    let mut yaros = QemuInstance::start().await?;
+    let mut yaos = QemuInstance::start().await?;
 
-    let output = yaros.run_prog("prog1").await?;
+    let output = yaos.run_prog("prog1").await?;
     assert_eq!(output, "Hello from Prog1\n");
 
-    let output = yaros.run_prog("prog2").await?;
+    let output = yaos.run_prog("prog2").await?;
     assert_eq!(output, "Hello from Prog2\n");
 
     Ok(())

--- a/system-tests/src/tests/net.rs
+++ b/system-tests/src/tests/net.rs
@@ -6,10 +6,9 @@ use crate::infra::qemu::{QemuInstance, QemuOptions};
 #[file_serial]
 #[tokio::test]
 async fn udp() -> anyhow::Result<()> {
-    let mut yaros = QemuInstance::start_with(QemuOptions::default().add_network_card(true)).await?;
+    let mut yaos = QemuInstance::start_with(QemuOptions::default().add_network_card(true)).await?;
 
-    yaros
-        .run_prog_waiting_for("udp", "Listening on 1234\n")
+    yaos.run_prog_waiting_for("udp", "Listening on 1234\n")
         .await
         .expect("udp program must succeed to start");
 
@@ -17,21 +16,18 @@ async fn udp() -> anyhow::Result<()> {
     socket.connect("127.0.0.1:1234").await?;
 
     socket.send("42\n".as_bytes()).await?;
-    yaros.stdout().assert_read_until("42\n").await;
+    yaos.stdout().assert_read_until("42\n").await;
 
-    yaros
-        .stdin()
-        .write("Hello from YaROS!\n".as_bytes())
-        .await?;
+    yaos.stdin().write("Hello from YaOS!\n".as_bytes()).await?;
 
     let mut buf = [0; 128];
     let bytes = socket.recv(&mut buf).await?;
     let response = String::from_utf8_lossy(&buf[0..bytes]);
 
-    assert_eq!(response, "Hello from YaROS!\n");
+    assert_eq!(response, "Hello from YaOS!\n");
 
     socket.send("Finalize test\n".as_bytes()).await?;
-    yaros.stdout().assert_read_until("Finalize test\n").await;
+    yaos.stdout().assert_read_until("Finalize test\n").await;
 
     Ok(())
 }

--- a/system-tests/src/tests/panic.rs
+++ b/system-tests/src/tests/panic.rs
@@ -2,8 +2,8 @@ use crate::infra::qemu::QemuInstance;
 
 #[tokio::test]
 async fn panic() -> anyhow::Result<()> {
-    let mut yaros = QemuInstance::start().await?;
-    let output = yaros
+    let mut yaos = QemuInstance::start().await?;
+    let output = yaos
         .run_prog_waiting_for("panic", "Time to attach gdb ;) use 'just attach'")
         .await?;
 

--- a/system-tests/src/tests/signals.rs
+++ b/system-tests/src/tests/signals.rs
@@ -9,16 +9,15 @@ use crate::infra::{
 #[file_serial]
 #[tokio::test]
 async fn should_exit_program() -> anyhow::Result<()> {
-    let mut yaros = QemuInstance::start_with(QemuOptions::default().add_network_card(true)).await?;
+    let mut yaos = QemuInstance::start_with(QemuOptions::default().add_network_card(true)).await?;
 
-    yaros
-        .run_prog_waiting_for("udp", "Listening on 1234")
+    yaos.run_prog_waiting_for("udp", "Listening on 1234")
         .await?;
 
-    yaros.stdin().write_all(&[0x03]).await?;
+    yaos.stdin().write_all(&[0x03]).await?;
 
-    yaros.stdout().assert_read_until(PROMPT).await;
-    let output = yaros.run_prog("prog1").await?;
+    yaos.stdout().assert_read_until(PROMPT).await;
+    let output = yaos.run_prog("prog1").await?;
     assert_eq!(output, "Hello from Prog1\n");
 
     Ok(())
@@ -26,11 +25,11 @@ async fn should_exit_program() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn should_not_exit_yash() -> anyhow::Result<()> {
-    let mut yaros = QemuInstance::start().await?;
+    let mut yaos = QemuInstance::start().await?;
 
-    yaros.stdin().write_all(&[0x03]).await?;
+    yaos.stdin().write_all(&[0x03]).await?;
 
-    let output = yaros.run_prog("prog1").await?;
+    let output = yaos.run_prog("prog1").await?;
     assert_eq!(output, "Hello from Prog1\n");
 
     Ok(())


### PR DESCRIPTION
Somehow YaOS feels cleaner and we also don't get in any conflict by using Rust in our name.