### PR TITLE
build: Update apt-get before install

### DIFF
--- a/.github/workflows/setup.sh
+++ b/.github/workflows/setup.sh
@@ -5,6 +5,7 @@ cd "$(dirname "$0")"
 
 TOOLCHAIN=$(cat ../../rust-toolchain | grep channel | awk '{print $3}' | tr -d '"')
 
+sudo apt-get update
 sudo apt-get install -y qemu-system-riscv64 binutils-riscv64-linux-gnu curl
 sudo rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Otherwise we use old mirror ips and the setup process is failing.