### PR TITLE
mmio: Explicit read and write

### DIFF
--- a/kernel/src/drivers/virtio/capability.rs
+++ b/kernel/src/drivers/virtio/capability.rs
@@ -1,3 +1,5 @@
+use crate::mmio_struct;
+
 // cfg_type values
 /* Common configuration */
 pub const VIRTIO_PCI_CAP_COMMON_CFG: u8 = 1;
@@ -19,35 +21,17 @@ pub const VIRTIO_PCI_CAP_SHARED_MEMORY_CFG: u8 = 8;
 #[allow(dead_code)]
 pub const VIRTIO_PCI_CAP_VENDOR_CFG: u8 = 9;
 
-#[allow(dead_code, non_camel_case_types)]
-#[derive(Debug)]
-#[repr(packed)]
-pub(super) struct virtio_pci_cap {
-    cap_vndr: u8,     /* Generic PCI field: PCI_CAP_ID_VNDR */
-    cap_next: u8,     /* Generic PCI field: next ptr. */
-    cap_len: u8,      /* Generic PCI field: capability length */
-    cfg_type: u8,     /* Identifies the structure. */
-    bar: u8,          /* Where to find it. */
-    id: u8,           /* Multiple capabilities of the same type */
-    padding: [u8; 2], /* Pad to full dword. */
-    offset: u32,      /* Offset within bar. */
-    length: u32,      /* Length of the structure, in bytes. */
-}
-
-impl virtio_pci_cap {
-    pub fn cfg_type(&self) -> u8 {
-        self.cfg_type
-    }
-
-    pub fn bar(&self) -> u8 {
-        self.bar
-    }
-
-    pub fn length(&self) -> u32 {
-        self.length
-    }
-
-    pub fn offset(&self) -> usize {
-        self.offset as usize
+mmio_struct! {
+    #[repr(packed)]
+    struct virtio_pci_cap {
+        cap_vndr: u8,     /* Generic PCI field: PCI_CAP_ID_VNDR */
+        cap_next: u8,     /* Generic PCI field: next ptr. */
+        cap_len: u8,      /* Generic PCI field: capability length */
+        cfg_type: u8,     /* Identifies the structure. */
+        bar: u8,          /* Where to find it. */
+        id: u8,           /* Multiple capabilities of the same type */
+        padding: [u8; 2], /* Pad to full dword. */
+        offset: u32,      /* Offset within bar. */
+        length: u32,      /* Length of the structure, in bytes. */
     }
 }

--- a/kernel/src/drivers/virtio/virtqueue.rs
+++ b/kernel/src/drivers/virtio/virtqueue.rs
@@ -177,7 +177,7 @@ impl<const QUEUE_SIZE: usize> VirtQueue<QUEUE_SIZE> {
 
     pub fn notify(&mut self) {
         if let Some(notify) = &mut self.notify {
-            **notify = self.queue_index;
+            notify.write(self.queue_index);
         }
     }
 }

--- a/kernel/src/interrupts/plic.rs
+++ b/kernel/src/interrupts/plic.rs
@@ -17,34 +17,34 @@ impl Plic {
     const unsafe fn new(plic_base: usize) -> Self {
         // These constants are set to interrupt context 1 which corresponds to Supervisor Mode on Hart 0
         // If we support multiple harts, we will need to change these constants to be configurable
-        unsafe {
-            Self {
-                priority_register_base: MMIO::new(plic_base),
-                // pending_register: MMIO::new(plic_base + 0x1000),
-                enable_register: MMIO::new(plic_base + 0x2080),
-                threshold_register: MMIO::new(plic_base + 0x20_1000),
-                claim_complete_register: MMIO::new(plic_base + 0x20_1004),
-            }
+        Self {
+            priority_register_base: MMIO::new(plic_base),
+            // pending_register: MMIO::new(plic_base + 0x1000),
+            enable_register: MMIO::new(plic_base + 0x2080),
+            threshold_register: MMIO::new(plic_base + 0x20_1000),
+            claim_complete_register: MMIO::new(plic_base + 0x20_1004),
         }
     }
     pub fn enable(&mut self, interrupt_id: u32) {
-        *self.enable_register |= 1 << interrupt_id;
+        self.enable_register |= 1 << interrupt_id;
     }
 
     pub fn set_priority(&mut self, interrupt_id: u32, priority: u32) {
         assert!(priority <= 7);
         unsafe {
-            *self.priority_register_base.add(interrupt_id as usize) = priority;
+            self.priority_register_base
+                .add(interrupt_id as usize)
+                .write(priority);
         }
     }
 
     pub fn set_threshold(&mut self, threshold: u32) {
         assert!(threshold <= 7);
-        *self.threshold_register = threshold;
+        self.threshold_register.write(threshold);
     }
 
     pub fn get_next_pending(&mut self) -> Option<InterruptSource> {
-        let open_interrupt = *self.claim_complete_register;
+        let open_interrupt = self.claim_complete_register.read();
 
         match open_interrupt {
             0 => None,
@@ -58,7 +58,7 @@ impl Plic {
             InterruptSource::Uart => UART_INTERRUPT_NUMBER,
             InterruptSource::Else => panic!("Invalid interrupt source to complete."),
         };
-        *self.claim_complete_register = interrupt_id;
+        self.claim_complete_register.write(interrupt_id);
     }
 }
 

--- a/kernel/src/klibc/mmio.rs
+++ b/kernel/src/klibc/mmio.rs
@@ -1,90 +1,254 @@
-use core::{
-    arch::asm,
-    fmt::{self, Debug, Pointer},
-    ops::{Deref, DerefMut},
-};
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign};
+
+use common::numbers::Number;
 
 #[allow(clippy::upper_case_acronyms)]
-pub struct MMIO<T: Sized> {
-    address: *mut T,
+pub struct MMIO<T> {
+    addr: *mut T,
 }
 
-// SAFETY: MMIO can be accessed from ANY thread
-unsafe impl<T: Sized> Send for MMIO<T> {}
-
 impl<T> MMIO<T> {
-    pub const unsafe fn new(address: usize) -> Self {
+    pub const fn new(addr: usize) -> Self {
         Self {
-            address: address as *mut T,
+            addr: addr as *mut T,
         }
     }
 
-    pub unsafe fn add(&self, count: usize) -> Self {
+    pub const unsafe fn add(&self, count: usize) -> Self {
         unsafe {
             Self {
-                address: self.address.add(count),
+                addr: self.addr.add(count),
             }
         }
     }
 
-    pub unsafe fn new_type<U>(&self) -> MMIO<U> {
+    pub const unsafe fn new_type<U>(&self) -> MMIO<U> {
         unsafe { self.new_type_with_offset(0) }
     }
 
-    pub unsafe fn new_type_with_offset<U>(&self, offset: usize) -> MMIO<U> {
+    pub const unsafe fn new_type_with_offset<U>(&self, offset: usize) -> MMIO<U> {
         unsafe {
             MMIO::<U> {
-                address: self.address.byte_add(offset) as *mut U,
+                addr: self.addr.byte_add(offset) as *mut U,
             }
         }
     }
+}
 
-    fn memory_barrier(&self) {
-        // The Rust default is memory globber
-        // Use it to force re-read of assembly
-        unsafe {
-            asm!("");
-        }
+impl<T: Copy> MMIO<T> {
+    pub fn read(&self) -> T {
+        unsafe { self.addr.read_volatile() }
     }
 
-    fn memory_fence(&self) {
-        // Make sure that io writes and reads are in order
+    pub fn write(&mut self, value: T) {
         unsafe {
-            asm!("fence");
+            self.addr.write_volatile(value);
         }
     }
 }
 
-impl<T> Deref for MMIO<T> {
-    type Target = T;
+impl<T: Copy, const LENGTH: usize> MMIO<[T; LENGTH]> {
+    pub fn read_index(&self, index: usize) -> T {
+        self.get_index(index).read()
+    }
 
-    fn deref(&self) -> &Self::Target {
-        unsafe {
-            self.memory_barrier();
-            self.memory_fence();
-            &*self.address
-        }
+    pub fn write_index(&mut self, index: usize, value: T) {
+        self.get_index(index).write(value);
+    }
+
+    fn get_index(&self, index: usize) -> MMIO<T> {
+        assert!(index < LENGTH, "Access out of bounds");
+        unsafe { self.new_type_with_offset(index * core::mem::size_of::<T>()) }
     }
 }
 
-impl<T> DerefMut for MMIO<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe {
-            self.memory_barrier();
-            self.memory_fence();
-            &mut *self.address
-        }
+impl<T: Number + BitOr<T, Output = T>> BitOrAssign<T> for MMIO<T> {
+    fn bitor_assign(&mut self, rhs: T) {
+        self.write(self.read() | rhs)
     }
 }
 
-impl<T> Debug for MMIO<T> {
+impl<T: Number + BitAnd<T, Output = T>> BitAndAssign<T> for MMIO<T> {
+    fn bitand_assign(&mut self, rhs: T) {
+        self.write(self.read() & rhs)
+    }
+}
+
+unsafe impl<T> Send for MMIO<T> {}
+
+impl<T> core::fmt::Pointer for MMIO<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        fmt::Pointer::fmt(&self.address, f)
+        write!(f, "{:p}", self.addr)
     }
 }
 
-impl<T> Pointer for MMIO<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Pointer::fmt(&self.address, f)
+impl<T: core::fmt::Debug + Copy> core::fmt::Debug for MMIO<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?}", self.read())
+    }
+}
+
+#[macro_export]
+macro_rules! mmio_struct {
+    {
+        $(#[$meta:meta])*
+        struct $name:ident {
+            $($field_name:ident : $field_type:ty),* $(,)?
+        }
+    } => {
+            $(#[$meta])*
+            #[derive(Clone, Copy, Debug)]
+            #[allow(non_camel_case_types, dead_code)]
+            pub struct $name {
+                $(
+                    $field_name: $field_type,
+                )*
+            }
+
+            impl $crate::klibc::mmio::MMIO<$name> {
+                $(
+                    #[allow(dead_code)]
+                    pub const fn $field_name(&self) -> $crate::klibc::mmio::MMIO<$field_type> {
+                        unsafe {
+                            self.new_type_with_offset(core::mem::offset_of!($name, $field_name))
+                        }
+                    }
+                )*
+            }
+        };
+}
+
+#[cfg(test)]
+mod tests {
+    use core::{
+        any::Any,
+        cell::UnsafeCell,
+        mem::offset_of,
+        ptr::{addr_of, addr_of_mut},
+    };
+
+    use crate::io::uart::QEMU_UART;
+
+    use super::*;
+
+    mmio_struct! {
+        #[repr(C)]
+        struct mmio_b {
+            b1: u16,
+            b2: [u8; 3],
+            b3: u64,
+        }
+    }
+
+    mmio_struct! {
+        #[repr(C)]
+        struct mmio_a{
+            a1: u64,
+            a2: u8,
+            a3: mmio_b,
+            a4: u8
+        }
+    }
+
+    fn get_test_data() -> mmio_a {
+        mmio_a {
+            a1: 18,
+            a2: 43,
+            a3: mmio_b {
+                b1: 20,
+                b2: [100, 102, 103],
+                b3: 22,
+            },
+            a4: 199,
+        }
+    }
+
+    macro_rules! check_offset {
+        ($value:ident, $mmio: ident, $( $field_path:ident ).+) => {
+            let addr1 = addr_of!($value.$($field_path).+ );
+            let addr2 = $mmio.$( $field_path()).+.addr;
+            assert_eq!(addr1, addr2);
+        };
+    }
+
+    #[test_case]
+    fn print_works() {
+        let value = get_test_data();
+
+        unsafe {
+            QEMU_UART.disarm();
+        }
+
+        crate::println!("value at {:p}", &value);
+
+        let mmio = MMIO::<mmio_a>::new(&value as *const _ as usize);
+
+        crate::println!("{:?}", mmio);
+    }
+
+    #[test_case]
+    fn offsets() {
+        let value = get_test_data();
+
+        let mmio = MMIO::<mmio_a>::new(&value as *const _ as usize);
+
+        check_offset!(value, mmio, a1);
+        check_offset!(value, mmio, a2);
+        check_offset!(value, mmio, a3);
+
+        check_offset!(value, mmio, a3.b1);
+        check_offset!(value, mmio, a3.b2);
+        check_offset!(value, mmio, a3.b3);
+
+        check_offset!(value, mmio, a4);
+    }
+
+    #[test_case]
+    fn struct_case() {
+        let value = UnsafeCell::new(get_test_data());
+        let ptr = value.get();
+
+        let mmio = MMIO::<mmio_a>::new(ptr as usize);
+
+        mmio.a1().write(0);
+        mmio.a2().write(1);
+        mmio.a3().b1().write(2);
+        mmio.a3().b2().write_index(0, 3);
+        mmio.a3().b2().write_index(1, 4);
+        mmio.a3().b2().write_index(2, 5);
+        mmio.a3().b3().write(6);
+        mmio.a4().write(7);
+
+        drop(mmio);
+
+        let read_value = unsafe { value.get().read_unaligned() };
+        unsafe {
+            assert_eq!(core::ptr::addr_of!(read_value.a1).read_unaligned(), 0);
+            assert_eq!(core::ptr::addr_of!(read_value.a2).read_unaligned(), 1);
+            assert_eq!(core::ptr::addr_of!(read_value.a3.b1).read_unaligned(), 2);
+            assert_eq!(core::ptr::addr_of!(read_value.a3.b2[0]).read_unaligned(), 3);
+            assert_eq!(core::ptr::addr_of!(read_value.a3.b2[1]).read_unaligned(), 4);
+            assert_eq!(core::ptr::addr_of!(read_value.a3.b2[2]).read_unaligned(), 5);
+            assert_eq!(core::ptr::addr_of!(read_value.a3.b3).read_unaligned(), 6);
+            assert_eq!(core::ptr::addr_of!(read_value.a4).read_unaligned(), 7);
+        }
+    }
+
+    #[test_case]
+    fn scalar() {
+        let mut value = UnsafeCell::new(42);
+        let ptr = value.get();
+
+        let mut mmio = MMIO::<i32>::new(ptr as usize);
+
+        assert_eq!(mmio.addr as *const i32, ptr);
+
+        assert_eq!(mmio.read(), 42);
+
+        mmio.write(128);
+
+        drop(mmio);
+
+        assert_eq!(*value.get_mut(), 128);
     }
 }

--- a/kernel/src/panic.rs
+++ b/kernel/src/panic.rs
@@ -5,6 +5,9 @@ use crate::{
 };
 use core::{panic::PanicInfo, sync::atomic::AtomicU8};
 
+#[cfg(test)]
+use crate::test::qemu_exit::exit_failure;
+
 static PANIC_COUNTER: AtomicU8 = AtomicU8::new(0);
 
 #[cfg(not(miri))]
@@ -34,6 +37,11 @@ fn panic(info: &PanicInfo) -> ! {
     crate::debugging::dump_current_state();
 
     println!("Time to attach gdb ;) use 'just attach'");
+
+    #[cfg(test)]
+    exit_failure(1);
+
+    #[cfg(not(test))]
     wait_for_the_end();
 }
 
@@ -43,6 +51,11 @@ fn abort_if_double_panic() {
     if current >= 1 {
         println!("Panic in panic! ABORTING!");
         println!("Time to attach gdb ;) use 'just attach'");
+
+        #[cfg(test)]
+        exit_failure(1);
+
+        #[cfg(not(test))]
         wait_for_the_end();
     }
 }

--- a/kernel/src/test/qemu_exit.rs
+++ b/kernel/src/test/qemu_exit.rs
@@ -8,22 +8,24 @@ const EXIT_FAILURE_CODE: u32 = 0x3333;
 #[allow(dead_code)]
 const EXIT_RESET_CODE: u32 = 0x7777;
 
-static TEST_DEVICE: Mutex<MMIO<u32>> = Mutex::new(unsafe { MMIO::new(TEST_DEVICE_ADDRESSS) });
+static TEST_DEVICE: Mutex<MMIO<u32>> = Mutex::new(MMIO::new(TEST_DEVICE_ADDRESSS));
 
 pub fn exit_success() -> ! {
-    **TEST_DEVICE.lock() = EXIT_SUCCESS_CODE;
+    TEST_DEVICE.lock().write(EXIT_SUCCESS_CODE);
     wait_for_the_end();
 }
 
 #[allow(dead_code)]
 pub fn exit_failure(code: u16) -> ! {
-    **TEST_DEVICE.lock() = EXIT_FAILURE_CODE | ((code as u32) << 16);
+    TEST_DEVICE
+        .lock()
+        .write(EXIT_FAILURE_CODE | ((code as u32) << 16));
     wait_for_the_end();
 }
 
 #[allow(dead_code)]
 pub fn exit_reset() -> ! {
-    **TEST_DEVICE.lock() = EXIT_RESET_CODE;
+    TEST_DEVICE.lock().write(EXIT_RESET_CODE);
     wait_for_the_end();
 }
 


### PR DESCRIPTION
Originally I thought that the compiler now reorders mmio accesses because the output of the system-test was scrambled. However, this was not the case. This is fixed in bfe8cb151e73e5e036a982bedcd2d6c437b39ddd

Nevertheless, we put a lot of work into that and it is cleaner. So keep that change.