### PR TITLE
Fix page table corruption bug

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -134,9 +134,9 @@ extern "C" fn kernel_init(hart_id: usize, device_tree_pointer: *const ()) -> ! {
         net::assign_network_device(network_device);
     }
 
-    start_other_harts(hart_id, num_cpus);
+    info!("kernel_init done! Starting other harts");
 
-    info!("kernel_init done! Enabling interrupts");
+    start_other_harts(hart_id, num_cpus);
 
     prepare_for_scheduling();
 }
@@ -163,7 +163,6 @@ fn start_other_harts(current_hart_id: usize, number_of_cpus: usize) {
             continue;
         }
 
-        info!("Starting cpu {cpu_id}");
         let cpu_struct = Cpu::init(cpu_id);
         sbi::extensions::hart_state_extension::start_hart(
             cpu_id,

--- a/kernel/src/processes/process.rs
+++ b/kernel/src/processes/process.rs
@@ -3,7 +3,7 @@ use crate::{
     klibc::elf::ElfFile,
     memory::{page::PinnedHeapPages, page_tables::RootPageTableHolder, PAGE_SIZE},
     net::sockets::SharedAssignedSocket,
-    processes::loader::{self, LoadedElf, STACK_END},
+    processes::loader::{self, LoadedElf, STACK_END, STACK_START},
 };
 use alloc::{
     collections::{BTreeMap, BTreeSet},
@@ -99,16 +99,17 @@ impl Process {
 
         let mut page_table = RootPageTableHolder::new_with_kernel_mapping();
 
-        page_table.map_userspace(
+        page_table.map(
             STACK_END,
             stack_addr.get(),
             PAGE_SIZE,
             crate::memory::page_tables::XWRMode::ReadWrite,
+            false,
             "Stack".to_string(),
         );
 
         let mut register_state = TrapFrame::zero();
-        register_state[Register::sp] = stack_addr.get();
+        register_state[Register::sp] = STACK_START;
 
         Arc::new(Mutex::new(Self {
             name: "powersave".to_string(),

--- a/system-tests/src/infra/qemu.rs
+++ b/system-tests/src/infra/qemu.rs
@@ -9,12 +9,14 @@ use super::{read_asserter::ReadAsserter, PROMPT};
 
 pub struct QemuOptions {
     add_network_card: bool,
+    use_smp: bool,
 }
 
 impl Default for QemuOptions {
     fn default() -> Self {
         Self {
             add_network_card: false,
+            use_smp: true,
         }
     }
 }
@@ -24,10 +26,17 @@ impl QemuOptions {
         self.add_network_card = value;
         self
     }
+    pub fn use_smp(mut self, value: bool) -> Self {
+        self.use_smp = value;
+        self
+    }
 
     fn apply(self, command: &mut Command) {
         if self.add_network_card {
             command.arg("--net");
+        }
+        if self.use_smp {
+            command.arg("--smp");
         }
     }
 }

--- a/system-tests/src/tests/basics.rs
+++ b/system-tests/src/tests/basics.rs
@@ -3,8 +3,14 @@ use serial_test::file_serial;
 use crate::infra::qemu::{QemuInstance, QemuOptions};
 
 #[tokio::test]
-async fn boot() -> anyhow::Result<()> {
+async fn boot_smp() -> anyhow::Result<()> {
     QemuInstance::start().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn boot_single_core() -> anyhow::Result<()> {
+    QemuInstance::start_with(QemuOptions::default().use_smp(false)).await?;
     Ok(())
 }
 
@@ -19,7 +25,8 @@ async fn boot_with_network() -> anyhow::Result<()> {
 async fn shutdown() -> anyhow::Result<()> {
     let mut sentientos = QemuInstance::start().await?;
 
-    sentientos.run_prog_waiting_for("exit", "shutting down system")
+    sentientos
+        .run_prog_waiting_for("exit", "shutting down system")
         .await?;
 
     assert!(sentientos.wait_for_qemu_to_exit().await?.success());


### PR DESCRIPTION
I incidentally set the sp of the powersave process to the actual physical address. It therefore, overwrite some of the kernel memory because the stack is growing down.

Note to myself: We should make the kernel page tables readonly after creating them to prevent such things a bit better in the future.