### PR TITLE
Disable tests for stress binary

### DIFF
--- a/userspace/Cargo.toml
+++ b/userspace/Cargo.toml
@@ -57,3 +57,8 @@ bench = false
 name = "sesh"
 test = false
 bench = false
+
+[[bin]]
+name = "stress"
+test = false
+bench = false


### PR DESCRIPTION
This will disable the lsp warnings.