### PR TITLE
helix: Enable clippy as default check command

### DIFF
--- a/.helix/languages.toml
+++ b/.helix/languages.toml
@@ -2,3 +2,5 @@
 name = "rust"
 workspace-lsp-roots = ["./", "system-tests"]
 
+[language-server.rust-analyzer.config]
+check.command = "clippy"


### PR DESCRIPTION
With that we already catch clippy issues while coding.