### PR TITLE
ci: restrict respond job to sysheap actor to prevent prompt injection

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,10 +50,12 @@ jobs:
 
   respond:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && github.event.action != 'labeled' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == 'sysheap' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && github.event.action != 'labeled' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: [self-hosted, nix]
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- The `respond` job in `claude.yml` previously triggered for any comment mentioning `@claude` from any GitHub user — a prompt injection risk on a public repo
- Add `github.actor == 'sysheap'` as an outer guard so only the repo owner can invoke the respond job
- The `implement` job (label-based) was already safe since only maintainers can apply labels — no change needed there

## Test plan

- [ ] Comment `@claude` on a PR/issue as `sysheap` → job triggers
- [ ] Comment `@claude` from another account → job does NOT trigger

---
_Created by [Claude Code](https://claude.ai/code)_