### PR TITLE
refactor: remove clippy::cast_possible_truncation lint

### DIFF
--- a/kernel/src/drivers/bochs_display.rs
+++ b/kernel/src/drivers/bochs_display.rs
@@ -39,13 +39,11 @@ pub fn is_bochs_display(device: &PCIDevice) -> bool {
 }
 
 fn write_vbe_reg(dispi_base: usize, index: u16, value: u16) {
-    #[allow(clippy::cast_possible_truncation)]
     let offset = index as usize * 2;
     let mut reg: MMIO<u16> = MMIO::new(dispi_base + offset);
     reg.write(value);
 }
 
-#[allow(clippy::cast_possible_truncation)]
 pub fn initialize(mut pci_device: PCIDevice) {
     let bar0 = pci_device.get_or_initialize_bar(0);
     let bar2 = pci_device.get_or_initialize_bar(2);

--- a/kernel/src/drivers/virtio/block.rs
+++ b/kernel/src/drivers/virtio/block.rs
@@ -169,9 +169,7 @@ pub async fn read(index: usize, offset: usize, buf: &mut [u8]) -> Result<usize, 
     let cap = {
         let guard = BLOCK_DEVICES.lock();
         let dev = guard.get(index).ok_or(Errno::ENODEV)?;
-        #[allow(clippy::cast_possible_truncation)]
-        let cap = dev.capacity_bytes() as usize;
-        cap
+        dev.capacity_bytes() as usize
     };
 
     if offset >= cap {
@@ -217,9 +215,7 @@ pub async fn write(index: usize, offset: usize, data: &[u8]) -> Result<usize, Er
     let cap = {
         let guard = BLOCK_DEVICES.lock();
         let dev = guard.get(index).ok_or(Errno::ENODEV)?;
-        #[allow(clippy::cast_possible_truncation)]
-        let cap = dev.capacity_bytes() as usize;
-        cap
+        dev.capacity_bytes() as usize
     };
 
     if offset >= cap {

--- a/kernel/src/drivers/virtio/input.rs
+++ b/kernel/src/drivers/virtio/input.rs
@@ -179,7 +179,6 @@ impl InputDevice {
 
         // Setup eventq at index 0
         common_cfg.queue_select().write(0);
-        #[allow(clippy::cast_possible_truncation)]
         let queue_size = QUEUE_SIZE as u16;
         common_cfg.queue_size().write(queue_size);
         let mut event_queue: VirtQueue<QUEUE_SIZE> = VirtQueue::new(queue_size, 0);

--- a/kernel/src/drivers/virtio/rng.rs
+++ b/kernel/src/drivers/virtio/rng.rs
@@ -136,7 +136,6 @@ impl RngDevice {
         // Write our desired queue size to the device (VirtIO spec allows
         // reducing from the device maximum).
         common_cfg.queue_select().write(0);
-        #[allow(clippy::cast_possible_truncation)]
         let queue_size = QUEUE_SIZE as u16;
         common_cfg.queue_size().write(queue_size);
         let mut request_queue: VirtQueue<QUEUE_SIZE> = VirtQueue::new(queue_size, 0);

--- a/kernel/src/fs/devfs.rs
+++ b/kernel/src/fs/devfs.rs
@@ -87,7 +87,6 @@ impl VfsNode for DevBlock {
         self.ino
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn size(&self) -> usize {
         block::capacity(self.index) as usize
     }
@@ -312,7 +311,6 @@ pub fn register_framebuffer_device() {
 
 pub fn register_block_device(index: usize) {
     assert!(index < 26, "block device index must be < 26 (a-z)");
-    #[allow(clippy::cast_possible_truncation)]
     let suffix = (b'a' + index as u8) as char;
     let name = alloc::format!("vd{suffix}");
     let node: VfsNodeRef = Arc::new(DevBlock {

--- a/kernel/src/fs/ext2/inode.rs
+++ b/kernel/src/fs/ext2/inode.rs
@@ -7,7 +7,6 @@ use super::structures::{
     Ext2Inode, Ext2Superblock,
 };
 
-#[allow(clippy::cast_possible_truncation)]
 pub async fn read_inode(
     dev: usize,
     sb: &Ext2Superblock,
@@ -38,7 +37,6 @@ pub async fn read_inode(
     }
 }
 
-#[allow(clippy::cast_possible_truncation)]
 pub async fn read_inode_data(dev: usize, sb: &Ext2Superblock, inode: &Ext2Inode) -> Vec<u8> {
     let file_size = inode.i_size as usize;
     if file_size == 0 {
@@ -103,7 +101,6 @@ pub async fn read_inode_data(dev: usize, sb: &Ext2Superblock, inode: &Ext2Inode)
     data
 }
 
-#[allow(clippy::cast_possible_truncation)]
 async fn read_block_data(
     dev: usize,
     block_num: u32,
@@ -123,7 +120,6 @@ async fn read_block_data(
 
 async fn read_block_pointers(dev: usize, block_num: u32, block_size: usize) -> Vec<u32> {
     let mut buf = vec![0u8; block_size];
-    #[allow(clippy::cast_possible_truncation)]
     let offset = block_num as usize * block_size;
     let n = block::read(dev, offset, &mut buf)
         .await

--- a/kernel/src/fs/ext2/mod.rs
+++ b/kernel/src/fs/ext2/mod.rs
@@ -46,7 +46,6 @@ pub async fn mount_ext2(dev: usize) {
     info!("ext2: mounted at /mnt");
 }
 
-#[allow(clippy::cast_possible_truncation)]
 async fn read_superblock(dev: usize) -> Ext2Superblock {
     let sb_size = core::mem::size_of::<Ext2Superblock>();
     let mut buf = vec![0u8; sb_size];
@@ -63,7 +62,6 @@ async fn read_superblock(dev: usize) -> Ext2Superblock {
     }
 }
 
-#[allow(clippy::cast_possible_truncation)]
 async fn read_block_group_descriptors(
     dev: usize,
     sb: &Ext2Superblock,
@@ -109,7 +107,6 @@ fn build_tree<'a>(
                 } else if file_type == EXT2_FT_REG_FILE {
                     let child_inode = read_inode(dev, sb, bgds, child_ino).await;
                     let data = read_inode_data(dev, sb, &child_inode).await;
-                    #[allow(clippy::cast_possible_truncation)]
                     let file_size = child_inode.i_size as usize;
                     Ext2File::new(alloc_ino(), data, file_size)
                 } else {
@@ -121,7 +118,6 @@ fn build_tree<'a>(
             Ext2Dir::new(alloc_ino(), children) as VfsNodeRef
         } else if ext2_inode.is_regular() {
             let data = read_inode_data(dev, sb, &ext2_inode).await;
-            #[allow(clippy::cast_possible_truncation)]
             let file_size = ext2_inode.i_size as usize;
             Ext2File::new(alloc_ino(), data, file_size) as VfsNodeRef
         } else {
@@ -130,7 +126,6 @@ fn build_tree<'a>(
     })
 }
 
-#[allow(clippy::cast_possible_truncation)]
 fn parse_dir_entries(data: &[u8]) -> alloc::vec::Vec<(String, u32, u8)> {
     let mut entries = alloc::vec::Vec::new();
     let mut offset = 0;

--- a/kernel/src/fs/vfs.rs
+++ b/kernel/src/fs/vfs.rs
@@ -52,7 +52,6 @@ pub fn stat_from_node(node: &VfsNodeRef) -> headers::fs::stat {
 }
 
 pub fn statx_from_node(node: &VfsNodeRef) -> headers::fs::statx {
-    #[allow(clippy::cast_possible_truncation)]
     let mode = node.node_type().stat_mode() as u16;
     headers::fs::statx {
         stx_mask: 0x7ff,

--- a/kernel/src/klibc/util.rs
+++ b/kernel/src/klibc/util.rs
@@ -16,7 +16,6 @@ pub trait UsizeExt {
 }
 
 impl UsizeExt for u64 {
-    #[allow(clippy::cast_possible_truncation)]
     fn as_usize(self) -> usize {
         self as usize
     }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -15,7 +15,6 @@
 #![deny(clippy::redundant_else)]
 #![deny(clippy::manual_assert)]
 #![deny(clippy::large_stack_arrays)]
-#![deny(clippy::cast_possible_truncation)]
 #![deny(clippy::cast_sign_loss)]
 #![feature(nonzero_ops)]
 #![feature(custom_test_frameworks)]

--- a/kernel/src/net/ipv4.rs
+++ b/kernel/src/net/ipv4.rs
@@ -33,9 +33,7 @@ pub enum IpV4ParseError {
     PacketTooSmall,
 }
 
-#[allow(clippy::cast_possible_truncation)]
 pub const PROTOCOL_TCP: u8 = headers::socket::IPPROTO_TCP as u8;
-#[allow(clippy::cast_possible_truncation)]
 pub const PROTOCOL_UDP: u8 = headers::socket::IPPROTO_UDP as u8;
 
 impl IpV4Header {

--- a/kernel/src/net/tcp.rs
+++ b/kernel/src/net/tcp.rs
@@ -10,13 +10,9 @@ use crate::{
 
 use super::{ipv4::IpV4Header, mac::MacAddress};
 
-#[allow(clippy::cast_possible_truncation)]
 pub const FLAG_FIN: u16 = headers::socket::TH_FIN as u16;
-#[allow(clippy::cast_possible_truncation)]
 pub const FLAG_SYN: u16 = headers::socket::TH_SYN as u16;
-#[allow(clippy::cast_possible_truncation)]
 pub const FLAG_RST: u16 = headers::socket::TH_RST as u16;
-#[allow(clippy::cast_possible_truncation)]
 pub const FLAG_ACK: u16 = headers::socket::TH_ACK as u16;
 
 #[derive(Debug)]
@@ -38,7 +34,6 @@ impl ByteInterpretable for TcpHeader {}
 
 impl TcpHeader {
     const HEADER_SIZE: usize = core::mem::size_of::<Self>();
-    #[allow(clippy::cast_possible_truncation)]
     const TCP_PROTOCOL: u8 = headers::socket::IPPROTO_TCP as u8;
 
     pub fn source_port(&self) -> u16 {

--- a/kernel/src/net/tcp_connection.rs
+++ b/kernel/src/net/tcp_connection.rs
@@ -35,7 +35,6 @@ pub fn allocate_ephemeral_port() -> u16 {
     port
 }
 
-#[allow(clippy::cast_possible_truncation)]
 fn generate_iss() -> u32 {
     arch::timer::get_current_clocks() as u32
 }

--- a/kernel/src/pci/address.rs
+++ b/kernel/src/pci/address.rs
@@ -18,7 +18,7 @@ impl PciAddr {
     }
 
     /// Apply device-tree offset to translate from PCI to CPU address space.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    #[allow(clippy::cast_sign_loss)]
     pub const fn to_cpu_addr(self, offset: i64) -> PciCpuAddr {
         PciCpuAddr((self.0 as i64 + offset) as usize)
     }

--- a/kernel/src/processes/timer.rs
+++ b/kernel/src/processes/timer.rs
@@ -89,7 +89,6 @@ pub fn wakeup_wakers() {
     }
 }
 
-#[allow(clippy::cast_possible_truncation)]
 pub fn current_time() -> timespec {
     let clocks = arch::timer::get_current_clocks();
     let freq = *TIMEBASE_FREQ;

--- a/kernel/src/syscalls/fs_ops.rs
+++ b/kernel/src/syscalls/fs_ops.rs
@@ -196,7 +196,6 @@ impl LinuxSyscallHandler {
 
             out[pos..pos + 8].copy_from_slice(&entry.ino.to_le_bytes());
             out[pos + 8..pos + 16].copy_from_slice(&(entry_idx as i64).to_le_bytes());
-            #[allow(clippy::cast_possible_truncation)]
             let reclen_u16 = reclen as u16;
             out[pos + 16..pos + 18].copy_from_slice(&reclen_u16.to_le_bytes());
             out[pos + 18] = d_type;

--- a/kernel/src/syscalls/macros.rs
+++ b/kernel/src/syscalls/macros.rs
@@ -34,7 +34,6 @@ impl NeedsUserSpaceWrapper for c_int {
 
 impl NeedsUserSpaceWrapper for c_uint {
     type Wrapped = c_uint;
-    #[allow(clippy::cast_possible_truncation)]
     fn wrap_arg(
         value: usize,
         _process: ProcessRef,


### PR DESCRIPTION
## Summary
- Remove `#![deny(clippy::cast_possible_truncation)]` from `kernel/src/main.rs`
- Remove all 30 standalone `#[allow(clippy::cast_possible_truncation)]` annotations across 17 files
- The lint is too noisy for an OS kernel that frequently needs integer truncation casts

Closes #198

## Test plan
- [x] `just clippy` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)