### PR TITLE
ci: migrate from self-hosted nix to GitHub runners with Docker

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,11 +1,12 @@
 name: Setup
-description: Load Nix environment via direnv (requires checkout first)
+description: Configure build environment inside CI container
 
 runs:
   using: composite
   steps:
-    - name: Load environment
+    - name: Setup build environment
       shell: bash
       run: |
-        direnv allow .
-        direnv export gha >> "$GITHUB_ENV"
+        ln -sf "$LINUX_HEADERS_PATH" headers/linux_headers
+        ln -sf "$MUSL_HEADERS_PATH" headers/musl_headers
+        mkdir -p kernel/compiled_userspace_nix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,75 +6,126 @@ on:
   pull_request:
 
 concurrency:
-  group: ci
-  cancel-in-progress: false
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: write
 
 jobs:
+  container:
+    uses: ./.github/workflows/container.yml
+    permissions:
+      packages: write
+
   build:
-    runs-on: [self-hosted, nix]
+    needs: container
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.container.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          clean: false
       - uses: ./.github/actions/setup
       - run: just build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          retention-days: 1
+          path: |
+            kernel/compiled_userspace/
+            kernel/compiled_userspace_nix/
+            target-coreutils/bin/
+            target/riscv64gc-unknown-none-elf/release/kernel
+            symbols
 
   fmt:
-    needs: build
-    runs-on: [self-hosted, nix]
+    needs: container
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.container.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          clean: false
-      - uses: ./.github/actions/setup
       - run: cargo fmt --check
 
   clippy:
-    needs: build
-    runs-on: [self-hosted, nix]
+    needs: [container, build]
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.container.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          clean: false
       - uses: ./.github/actions/setup
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
       - run: just clippy
 
   unit-test:
-    needs: build
-    runs-on: [self-hosted, nix]
+    needs: [container, build]
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.container.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          clean: false
       - uses: ./.github/actions/setup
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
       - run: just unit-test
 
   miri:
-    needs: build
-    runs-on: [self-hosted, nix]
+    needs: [container, build]
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.container.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          clean: false
       - uses: ./.github/actions/setup
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
       - run: just miri
 
   system-test:
-    needs: build
-    runs-on: [self-hosted, nix]
+    needs: [container, build]
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.container.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          clean: false
       - uses: ./.github/actions/setup
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
       - run: just system-test
 
   kani:
-    needs: build
-    runs-on: [self-hosted, nix]
+    needs: container
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.container.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          clean: false
       - uses: ./.github/actions/setup
       - run: just kani

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,69 @@
+name: container
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      image:
+        description: Full container image reference
+        value: ${{ jobs.build.outputs.image }}
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.result.outputs.image }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute image tag
+        id: hash
+        run: |
+          HASH=$(sha256sum flake.nix flake.lock rust-toolchain nix/kani.nix | sha256sum | cut -c1-12)
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          echo "Image tag: $HASH"
+
+      - name: Check if image exists
+        id: check
+        run: |
+          IMAGE="ghcr.io/sysheap/solaya-ci:${{ steps.hash.outputs.hash }}"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Image already exists: $IMAGE"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Image not found, will build: $IMAGE"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to ghcr.io
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Nix
+        if: steps.check.outputs.exists == 'false'
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build container image
+        if: steps.check.outputs.exists == 'false'
+        run: nix build .#ci-image
+
+      - name: Load and push container image
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          docker load < result
+          docker tag ghcr.io/sysheap/solaya-ci:latest ${{ steps.check.outputs.image }}
+          docker push ${{ steps.check.outputs.image }}
+
+      - name: Set output
+        id: result
+        run: echo "image=${{ steps.check.outputs.image }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -26,6 +26,13 @@ jobs:
           echo "hash=$HASH" >> "$GITHUB_OUTPUT"
           echo "Image tag: $HASH"
 
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check if image exists
         id: check
         run: |
@@ -38,16 +45,6 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "Image not found, will build: $IMAGE"
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to ghcr.io
-        if: steps.check.outputs.exists == 'false'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Nix
         if: steps.check.outputs.exists == 'false'

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -27,7 +27,7 @@ jobs:
           echo "Image tag: $HASH"
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,9 @@ mcp-server/target/
 /symbols
 /.direnv
 /.gdb_sources
-/musl
 /headers/musl_headers
 
 __pycache__/
 disk.img
+userspace/dash/build/
+userspace/doom/build/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ __pycache__/
 disk.img
 userspace/dash/build/
 userspace/doom/build/
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,18 @@
 {
   "nodes": {
+    "dash-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1670740934,
+        "narHash": "sha256-cL8rcGuwzcraI5zOZTt0Me9H1IJCXBBmOtgzbGqPSM4=",
+        "type": "tarball",
+        "url": "http://gondor.apana.org.au/~herbert/dash/files/dash-0.5.12.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "http://gondor.apana.org.au/~herbert/dash/files/dash-0.5.12.tar.gz"
+      }
+    },
     "doom1-wad": {
       "flake": false,
       "locked": {
@@ -137,6 +150,7 @@
     },
     "root": {
       "inputs": {
+        "dash-src": "dash-src",
         "doom1-wad": "doom1-wad",
         "doomgeneric": "doomgeneric",
         "flake-utils": "flake-utils",

--- a/flake.nix
+++ b/flake.nix
@@ -159,7 +159,6 @@
               mkdir -p $out/lib
               ln -s ${pkgs.glibc}/lib/* $out/lib/
               ln -s ${pkgs.stdenv.cc.cc.lib}/lib/libstdc++.so* $out/lib/
-              ln -s ${pkgs.stdenv.cc.cc.lib}/lib/libstdc++.so* $out/lib64/
             '';
           in
           pkgs.dockerTools.buildLayeredImage {
@@ -179,6 +178,7 @@
                 "DOOM1_WAD=/opt/doom1.wad"
                 "DASH_SRC=/opt/dash-src"
                 "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                "LD_LIBRARY_PATH=/lib"
               ];
               Cmd = [ "${pkgs.bash}/bin/bash" ];
             };

--- a/flake.nix
+++ b/flake.nix
@@ -151,6 +151,13 @@
               cp ${doom1-wad} $out/opt/doom1.wad
               ln -s ${dash-src} $out/opt/dash-src
             '';
+            # GitHub Actions mounts its own Node.js binary which needs glibc's dynamic linker
+            glibcLinker = pkgs.runCommand "glibc-linker" { } ''
+              mkdir -p $out/lib64
+              ln -s ${pkgs.glibc}/lib/ld-linux-x86-64.so.2 $out/lib64/ld-linux-x86-64.so.2
+              mkdir -p $out/lib
+              ln -s ${pkgs.glibc}/lib/* $out/lib/
+            '';
           in
           pkgs.dockerTools.buildLayeredImage {
             name = "ghcr.io/sysheap/solaya-ci";
@@ -158,6 +165,7 @@
             contents = [
               tools
               sources
+              glibcLinker
             ];
             config = {
               Env = [

--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,7 @@
               mkdir -p $out/lib
               ln -s ${pkgs.glibc}/lib/* $out/lib/
               ln -s ${pkgs.stdenv.cc.cc.lib}/lib/libstdc++.so* $out/lib/
+              ln -s ${pkgs.stdenv.cc.cc.lib}/lib/libstdc++.so* $out/lib64/
             '';
           in
           pkgs.dockerTools.buildLayeredImage {

--- a/flake.nix
+++ b/flake.nix
@@ -133,6 +133,7 @@
                 pkgs.gnutar
                 pkgs.gzip
                 pkgs.gnumake
+                pkgs.gcc
                 pkgs.qemu
                 pkgs.cargo-nextest
                 pkgs.just

--- a/flake.nix
+++ b/flake.nix
@@ -116,48 +116,62 @@
           }
         );
 
-        packages.ci-image = pkgs.dockerTools.buildLayeredImage {
-          name = "ghcr.io/sysheap/solaya-ci";
-          tag = "latest";
-          contents = [
-            pkgs.bash
-            pkgs.coreutils
-            pkgs.git
-            pkgs.cacert
-            pkgs.gnugrep
-            pkgs.findutils
-            pkgs.gawk
-            pkgs.gnused
-            pkgs.gnutar
-            pkgs.gzip
-            pkgs.gnumake
-            pkgs.qemu
-            pkgs.cargo-nextest
-            pkgs.just
-            rustToolchain
-            kani
-            riscv-toolchain.buildPackages.gcc
-            riscv-toolchain.buildPackages.binutils
-            pkgs.llvmPackages.libclang.lib
-            musl-riscv.dev
-            musl-riscv.linuxHeaders
-            doomgeneric
-            doom1-wad
-            dash-src
-          ];
-          config = {
-            Env = [
-              "LIBCLANG_PATH=${pkgs.llvmPackages.libclang.lib}/lib"
-              "LINUX_HEADERS_PATH=${musl-riscv.linuxHeaders}"
-              "MUSL_HEADERS_PATH=${musl-riscv.dev}/include"
-              "DOOMGENERIC_SRC=${doomgeneric}"
-              "DOOM1_WAD=${doom1-wad}"
-              "DASH_SRC=${dash-src}"
-              "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+        packages.ci-image =
+          let
+            tools = pkgs.buildEnv {
+              name = "solaya-ci-tools";
+              paths = [
+                pkgs.bash
+                pkgs.coreutils
+                pkgs.git
+                pkgs.cacert
+                pkgs.gnugrep
+                pkgs.findutils
+                pkgs.gawk
+                pkgs.gnused
+                pkgs.gnutar
+                pkgs.gzip
+                pkgs.gnumake
+                pkgs.qemu
+                pkgs.cargo-nextest
+                pkgs.just
+                rustToolchain
+                kani
+                riscv-toolchain.buildPackages.gcc.out
+                riscv-toolchain.buildPackages.binutils.out
+                pkgs.llvmPackages.libclang.lib
+                musl-riscv.dev
+                musl-riscv.linuxHeaders
+              ];
+              ignoreCollisions = true;
+            };
+            sources = pkgs.runCommand "solaya-ci-sources" { } ''
+              mkdir -p $out/opt
+              ln -s ${doomgeneric} $out/opt/doomgeneric
+              cp ${doom1-wad} $out/opt/doom1.wad
+              ln -s ${dash-src} $out/opt/dash-src
+            '';
+          in
+          pkgs.dockerTools.buildLayeredImage {
+            name = "ghcr.io/sysheap/solaya-ci";
+            tag = "latest";
+            contents = [
+              tools
+              sources
             ];
-            Cmd = [ "${pkgs.bash}/bin/bash" ];
+            config = {
+              Env = [
+                "LIBCLANG_PATH=${pkgs.llvmPackages.libclang.lib}/lib"
+                "LINUX_HEADERS_PATH=${musl-riscv.linuxHeaders}"
+                "MUSL_HEADERS_PATH=${musl-riscv.dev}/include"
+                "DOOMGENERIC_SRC=/opt/doomgeneric"
+                "DOOM1_WAD=/opt/doom1.wad"
+                "DASH_SRC=/opt/dash-src"
+                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+              ];
+              Cmd = [ "${pkgs.bash}/bin/bash" ];
+            };
           };
-        };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,10 @@
       url = "https://distro.ibiblio.org/slitaz/sources/packages/d/doom1.wad";
       flake = false;
     };
+    dash-src = {
+      url = "http://gondor.apana.org.au/~herbert/dash/files/dash-0.5.12.tar.gz";
+      flake = false;
+    };
   };
 
   outputs =
@@ -28,6 +32,7 @@
       pwndbg,
       doomgeneric,
       doom1-wad,
+      dash-src,
       ...
     }:
     flake-utils.lib.eachDefaultSystem (
@@ -57,62 +62,6 @@
 
         musl-riscv = riscv-toolchain.musl;
 
-        dash = riscv-toolchain.dash.overrideAttrs (old: {
-          hardeningDisable = [ "fortify" ];
-          separateDebugInfo = false;
-          dontStrip = true;
-        });
-
-        doom-riscv = pkgs.stdenv.mkDerivation {
-          name = "doom-riscv";
-          src = doomgeneric;
-          nativeBuildInputs = [
-            riscv-toolchain.buildPackages.gcc
-            riscv-toolchain.buildPackages.binutils
-          ];
-          buildPhase = ''
-            cd doomgeneric
-            cp ${./userspace/doom/dg_solaya.c} dg_solaya.c
-            cp ${./userspace/doom/i_video_solaya.c} i_video.c
-
-            # Embed doom1.wad as a binary object in a separate directory
-            cp ${doom1-wad} doom1.wad
-            mkdir -p wad_obj
-            riscv64-unknown-linux-musl-ld -r -b binary -o wad_obj/doom1_wad.o doom1.wad
-
-            CC=riscv64-unknown-linux-musl-gcc
-            CFLAGS="-static -O3 -DNORMALUNIX -DLINUX -D_DEFAULT_SOURCE -I."
-
-            SRCS="
-              dummy.c am_map.c doomdef.c doomstat.c dstrings.c
-              d_event.c d_items.c d_iwad.c d_loop.c d_main.c d_mode.c d_net.c
-              f_finale.c f_wipe.c g_game.c hu_lib.c hu_stuff.c info.c
-              i_cdmus.c i_endoom.c i_joystick.c i_scale.c i_sound.c i_system.c
-              i_timer.c memio.c m_argv.c m_bbox.c m_cheat.c m_config.c
-              m_controls.c m_fixed.c m_menu.c m_misc.c m_random.c
-              p_ceilng.c p_doors.c p_enemy.c p_floor.c p_inter.c p_lights.c
-              p_map.c p_maputl.c p_mobj.c p_plats.c p_pspr.c p_saveg.c
-              p_setup.c p_sight.c p_spec.c p_switch.c p_telept.c p_tick.c
-              p_user.c r_bsp.c r_data.c r_draw.c r_main.c r_plane.c r_segs.c
-              r_sky.c r_things.c sha1.c sounds.c statdump.c st_lib.c st_stuff.c
-              s_sound.c tables.c v_video.c wi_stuff.c w_checksum.c w_file.c
-              w_main.c w_wad.c z_zone.c w_file_stdc.c i_input.c i_video.c
-              mus2mid.c doomgeneric.c dg_solaya.c
-            "
-
-            for f in $SRCS; do
-              echo "CC $f"
-              $CC $CFLAGS -c $f -o ''${f%.c}.o
-            done
-
-            $CC $CFLAGS -o doom *.o wad_obj/doom1_wad.o -lm
-          '';
-          installPhase = ''
-            mkdir -p $out/bin
-            cp doom $out/bin/doom
-          '';
-        };
-
         basePackages = [
           pkgs.qemu
           pkgs.cargo-nextest
@@ -133,16 +82,17 @@
         };
 
         hook = ''
-          rm -rf musl headers/linux_headers headers/musl_headers
+          rm -rf headers/linux_headers headers/musl_headers
 
-          ln -sf ${musl-riscv}/src musl
           ln -sf ${musl-riscv.linuxHeaders}/ headers/linux_headers
           ln -sf ${musl-riscv.dev}/include headers/musl_headers
 
+          export DOOMGENERIC_SRC=${doomgeneric}
+          export DOOM1_WAD=${doom1-wad}
+          export DASH_SRC=${dash-src}
+
           mkdir -p kernel/compiled_userspace_nix
-          ln -sf "${dash}/bin/dash" "./kernel/compiled_userspace_nix/dash"
-          ln -sf "${dash}/bin/dash" "./kernel/compiled_userspace_nix/sh"
-          ln -sf "${doom-riscv}/bin/doom" "./kernel/compiled_userspace_nix/doom"
+          just build-dash build-doom
 
           just mcp-server
         '';
@@ -159,11 +109,55 @@
               pkgs.typos-lsp
               pkgs.dtc
               pkgs.e2fsprogs
+              pkgs.gnumake
             ]
             ++ basePackages;
             shellHook = hook;
           }
         );
+
+        packages.ci-image = pkgs.dockerTools.buildLayeredImage {
+          name = "ghcr.io/sysheap/solaya-ci";
+          tag = "latest";
+          contents = [
+            pkgs.bash
+            pkgs.coreutils
+            pkgs.git
+            pkgs.cacert
+            pkgs.gnugrep
+            pkgs.findutils
+            pkgs.gawk
+            pkgs.gnused
+            pkgs.gnutar
+            pkgs.gzip
+            pkgs.gnumake
+            pkgs.qemu
+            pkgs.cargo-nextest
+            pkgs.just
+            rustToolchain
+            kani
+            riscv-toolchain.buildPackages.gcc
+            riscv-toolchain.buildPackages.binutils
+            pkgs.llvmPackages.libclang.lib
+            musl-riscv.dev
+            musl-riscv.linuxHeaders
+            doomgeneric
+            doom1-wad
+            dash-src
+          ];
+          config = {
+            Env = [
+              "LIBCLANG_PATH=${pkgs.llvmPackages.libclang.lib}/lib"
+              "LINUX_HEADERS_PATH=${musl-riscv.linuxHeaders}"
+              "MUSL_HEADERS_PATH=${musl-riscv.dev}/include"
+              "DOOMGENERIC_SRC=${doomgeneric}"
+              "DOOM1_WAD=${doom1-wad}"
+              "DASH_SRC=${dash-src}"
+              "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            ];
+            Cmd = [ "${pkgs.bash}/bin/bash" ];
+          };
+        };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -151,12 +151,13 @@
               cp ${doom1-wad} $out/opt/doom1.wad
               ln -s ${dash-src} $out/opt/dash-src
             '';
-            # GitHub Actions mounts its own Node.js binary which needs glibc's dynamic linker
+            # GitHub Actions mounts its own Node.js binary which needs glibc + libstdc++
             glibcLinker = pkgs.runCommand "glibc-linker" { } ''
               mkdir -p $out/lib64
               ln -s ${pkgs.glibc}/lib/ld-linux-x86-64.so.2 $out/lib64/ld-linux-x86-64.so.2
               mkdir -p $out/lib
               ln -s ${pkgs.glibc}/lib/* $out/lib/
+              ln -s ${pkgs.stdenv.cc.cc.lib}/lib/libstdc++.so* $out/lib/
             '';
           in
           pkgs.dockerTools.buildLayeredImage {

--- a/flake.nix
+++ b/flake.nix
@@ -110,6 +110,7 @@
               pkgs.dtc
               pkgs.e2fsprogs
               pkgs.gnumake
+              pkgs.skopeo
             ]
             ++ basePackages;
             shellHook = hook;

--- a/justfile
+++ b/justfile
@@ -15,14 +15,12 @@ build-cargo: build-userspace build-dash build-doom
 
 docker-build:
     nix build .#ci-image
-    docker load < result
 
 docker-push: docker-build
     #!/usr/bin/env bash
     HASH=$(sha256sum flake.nix flake.lock rust-toolchain nix/kani.nix | sha256sum | cut -c1-12)
     IMAGE="ghcr.io/sysheap/solaya-ci"
-    docker tag ${IMAGE}:latest ${IMAGE}:${HASH}
-    docker push ${IMAGE}:${HASH}
+    skopeo copy docker-archive:result docker://${IMAGE}:${HASH}
     echo "Pushed ${IMAGE}:${HASH}"
 
 COREUTILS_FEATURES := "cat,echo,false,ls,mkdir,pwd,rm,touch,true"

--- a/justfile
+++ b/justfile
@@ -4,8 +4,26 @@ patch-symbols:
     riscv64-unknown-linux-musl-nm --demangle --numeric-sort --line-numbers target/riscv64gc-unknown-none-elf/release/kernel | grep -e ' t ' -e ' T ' > symbols && printf '\0' >> symbols
     riscv64-unknown-linux-musl-objcopy --update-section symbols=./symbols target/riscv64gc-unknown-none-elf/release/kernel
 
-build-cargo: build-userspace
+build-dash:
+    @test -f kernel/compiled_userspace_nix/dash || make -C userspace/dash
+
+build-doom:
+    @test -f kernel/compiled_userspace_nix/doom || make -C userspace/doom
+
+build-cargo: build-userspace build-dash build-doom
     cargo build --release
+
+docker-build:
+    nix build .#ci-image
+    docker load < result
+
+docker-push: docker-build
+    #!/usr/bin/env bash
+    HASH=$(sha256sum flake.nix flake.lock rust-toolchain nix/kani.nix | sha256sum | cut -c1-12)
+    IMAGE="ghcr.io/sysheap/solaya-ci"
+    docker tag ${IMAGE}:latest ${IMAGE}:${HASH}
+    docker push ${IMAGE}:${HASH}
+    echo "Pushed ${IMAGE}:${HASH}"
 
 COREUTILS_FEATURES := "cat,echo,false,ls,mkdir,pwd,rm,touch,true"
 

--- a/userspace/dash/Makefile
+++ b/userspace/dash/Makefile
@@ -1,0 +1,31 @@
+OUTPUT_DIR := ../../kernel/compiled_userspace_nix
+TARGETS := $(OUTPUT_DIR)/dash $(OUTPUT_DIR)/sh
+
+CC := riscv64-unknown-linux-musl-gcc
+CFLAGS :=
+LDFLAGS := -static
+
+.PHONY: all clean
+
+all: $(TARGETS)
+
+$(OUTPUT_DIR)/dash: build/src/dash
+	mkdir -p $(OUTPUT_DIR)
+	cp $< $@
+
+$(OUTPUT_DIR)/sh: $(OUTPUT_DIR)/dash
+	ln -sf dash $@
+
+build/src/dash: build/configure
+	cd build && ./configure --host=riscv64-unknown-linux-musl CC="$(CC)" LDFLAGS="$(LDFLAGS)"
+	$(MAKE) -C build
+
+build/configure:
+	@test -n "$(DASH_SRC)" || { echo "Error: DASH_SRC not set"; exit 1; }
+	mkdir -p build
+	cp -r $(DASH_SRC)/* build/
+	chmod -R u+w build
+	cd build && touch aclocal.m4 configure config.h.in Makefile.in src/Makefile.in
+
+clean:
+	rm -rf build $(TARGETS)

--- a/userspace/doom/Makefile
+++ b/userspace/doom/Makefile
@@ -1,0 +1,53 @@
+OUTPUT_DIR := ../../kernel/compiled_userspace_nix
+TARGET := $(OUTPUT_DIR)/doom
+
+CC := riscv64-unknown-linux-musl-gcc
+LD := riscv64-unknown-linux-musl-ld
+CFLAGS := -static -O3 -DNORMALUNIX -DLINUX -D_DEFAULT_SOURCE -I build
+SOLAYA_DIR := $(CURDIR)
+
+SRCS := \
+	dummy.c am_map.c doomdef.c doomstat.c dstrings.c \
+	d_event.c d_items.c d_iwad.c d_loop.c d_main.c d_mode.c d_net.c \
+	f_finale.c f_wipe.c g_game.c hu_lib.c hu_stuff.c info.c \
+	i_cdmus.c i_endoom.c i_joystick.c i_scale.c i_sound.c i_system.c \
+	i_timer.c memio.c m_argv.c m_bbox.c m_cheat.c m_config.c \
+	m_controls.c m_fixed.c m_menu.c m_misc.c m_random.c \
+	p_ceilng.c p_doors.c p_enemy.c p_floor.c p_inter.c p_lights.c \
+	p_map.c p_maputl.c p_mobj.c p_plats.c p_pspr.c p_saveg.c \
+	p_setup.c p_sight.c p_spec.c p_switch.c p_telept.c p_tick.c \
+	p_user.c r_bsp.c r_data.c r_draw.c r_main.c r_plane.c r_segs.c \
+	r_sky.c r_things.c sha1.c sounds.c statdump.c st_lib.c st_stuff.c \
+	s_sound.c tables.c v_video.c wi_stuff.c w_checksum.c w_file.c \
+	w_main.c w_wad.c z_zone.c w_file_stdc.c i_input.c i_video.c \
+	mus2mid.c doomgeneric.c dg_solaya.c
+
+.PHONY: all clean
+
+all: $(TARGET)
+
+$(TARGET): build/.prepared
+	@echo "Compiling doom..."
+	@cd build && for f in $(SRCS); do \
+		echo "  CC $$f"; \
+		$(CC) $(CFLAGS) -c $$f -o $${f%.c}.o || exit 1; \
+	done
+	mkdir -p build/wad_obj
+	cd build && $(LD) -r -b binary -o wad_obj/doom1_wad.o doom1.wad
+	cd build && $(CC) $(CFLAGS) -o doom *.o wad_obj/doom1_wad.o -lm
+	mkdir -p $(OUTPUT_DIR)
+	cp build/doom $@
+
+build/.prepared:
+	@test -n "$(DOOMGENERIC_SRC)" || { echo "Error: DOOMGENERIC_SRC not set"; exit 1; }
+	@test -n "$(DOOM1_WAD)" || { echo "Error: DOOM1_WAD not set"; exit 1; }
+	mkdir -p build
+	cp -r $(DOOMGENERIC_SRC)/doomgeneric/* build/
+	cp $(SOLAYA_DIR)/dg_solaya.c build/
+	cp $(SOLAYA_DIR)/i_video_solaya.c build/i_video.c
+	cp $(DOOM1_WAD) build/doom1.wad
+	chmod -R u+w build
+	touch $@
+
+clean:
+	rm -rf build $(TARGET)


### PR DESCRIPTION
## Summary

- **Docker container image**: New `packages.ci-image` nix output builds a minimal container with all build tools (Rust toolchain, RISC-V cross-compiler, QEMU, Kani, etc.). Pushed to ghcr.io with hash-based tags for automatic cache invalidation.
- **Makefile-based dash/doom builds**: Moved dash and doom cross-compilation from nix derivations to `userspace/dash/Makefile` and `userspace/doom/Makefile`, eliminating nix rebuilds when only source files change.
- **CI rewrite**: All jobs now run on `ubuntu-latest` inside the container image. Build artifacts are uploaded/shared between jobs. `fmt` and `kani` run in parallel with `build`. Per-ref concurrency with cancel-in-progress.

## Test plan

- [x] `nix flake check --no-build` passes
- [x] `make -C userspace/dash` builds dash successfully in nix shell
- [x] `make -C userspace/doom` builds doom successfully in nix shell
- [x] `just build` completes end-to-end
- [ ] Build and push container locally: `just docker-push`
- [ ] Verify all CI jobs pass in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)