### PR TITLE
Switch CI to public runners with Nix cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,75 +6,36 @@ on:
   pull_request:
 
 concurrency:
-  group: ci
-  cancel-in-progress: false
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: [self-hosted, nix]
+  ci:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          clean: false
-      - uses: ./.github/actions/setup
-      - run: just build
 
-  fmt:
-    needs: build
-    runs-on: [self-hosted, nix]
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          clean: false
-      - uses: ./.github/actions/setup
-      - run: cargo fmt --check
+      - uses: DeterminateSystems/nix-installer-action@main
 
-  clippy:
-    needs: build
-    runs-on: [self-hosted, nix]
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          clean: false
-      - uses: ./.github/actions/setup
-      - run: just clippy
+      - uses: DeterminateSystems/magic-nix-cache-action@main
 
-  unit-test:
-    needs: build
-    runs-on: [self-hosted, nix]
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          clean: false
-      - uses: ./.github/actions/setup
-      - run: just unit-test
+      - name: Build
+        run: nix develop --command just build
 
-  miri:
-    needs: build
-    runs-on: [self-hosted, nix]
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          clean: false
-      - uses: ./.github/actions/setup
-      - run: just miri
+      - name: Format check
+        run: nix develop --command cargo fmt --check
 
-  system-test:
-    needs: build
-    runs-on: [self-hosted, nix]
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          clean: false
-      - uses: ./.github/actions/setup
-      - run: just system-test
+      - name: Clippy
+        run: nix develop --command just clippy
 
-  kani:
-    needs: build
-    runs-on: [self-hosted, nix]
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          clean: false
-      - uses: ./.github/actions/setup
-      - run: just kani
+      - name: Unit tests
+        run: nix develop --command just unit-test
+
+      - name: Miri
+        run: nix develop --command just miri
+
+      - name: System tests
+        run: nix develop --command just system-test
+
+      - name: Kani
+        run: nix develop --command just kani

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,23 +19,25 @@ jobs:
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
+      - uses: nicknovitski/nix-develop@v1
+
       - name: Build
-        run: nix develop --command just build
+        run: just build
 
       - name: Format check
-        run: nix develop --command cargo fmt --check
+        run: cargo fmt --check
 
       - name: Clippy
-        run: nix develop --command just clippy
+        run: just clippy
 
       - name: Unit tests
-        run: nix develop --command just unit-test
+        run: just unit-test
 
       - name: Miri
-        run: nix develop --command just miri
+        run: just miri
 
       - name: System tests
-        run: nix develop --command just system-test
+        run: just system-test
 
       - name: Kani
-        run: nix develop --command just kani
+        run: just kani

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - uses: nicknovitski/nix-develop@v1
+        with:
+          arguments: .#ci
 
       - name: Build
         run: just build

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,10 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+concurrency:
+  group: claude-code-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     if: github.actor == 'sysheap'

--- a/flake.nix
+++ b/flake.nix
@@ -113,18 +113,21 @@
           '';
         };
 
-        basePackages = [
+        ciPackages = [
           pkgs.qemu
           pkgs.cargo-nextest
           pkgs.just
-          (pkgs.python3.withPackages (ps: [
-            ps.pygdbmi
-            ps.mcp
-          ]))
           rustToolchain
           riscv-toolchain.buildPackages.gcc
           riscv-toolchain.buildPackages.binutils
           kani
+        ];
+
+        basePackages = ciPackages ++ [
+          (pkgs.python3.withPackages (ps: [
+            ps.pygdbmi
+            ps.mcp
+          ]))
         ];
 
         commonEnv = {
@@ -161,6 +164,14 @@
               pkgs.e2fsprogs
             ]
             ++ basePackages;
+            shellHook = hook;
+          }
+        );
+
+        devShells.ci = pkgs.mkShell (
+          commonEnv
+          // {
+            nativeBuildInputs = ciPackages;
             shellHook = hook;
           }
         );

--- a/flake.nix
+++ b/flake.nix
@@ -124,13 +124,6 @@
           pkgs.e2fsprogs
         ];
 
-        basePackages = ciPackages ++ [
-          (pkgs.python3.withPackages (ps: [
-            ps.pygdbmi
-            ps.mcp
-          ]))
-        ];
-
         commonEnv = {
           # Needed for bindgen
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
@@ -156,14 +149,17 @@
         devShells.default = pkgs.mkShell (
           commonEnv
           // {
-            nativeBuildInputs = [
+            nativeBuildInputs = ciPackages ++ [
               pkgs.gdb
               pkgs.tmux
               pwndbg.packages.${system}.default
               pkgs.typos-lsp
               pkgs.dtc
-            ]
-            ++ basePackages;
+              (pkgs.python3.withPackages (ps: [
+                ps.pygdbmi
+                ps.mcp
+              ]))
+            ];
             shellHook = hook;
           }
         );

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,7 @@
           riscv-toolchain.buildPackages.gcc
           riscv-toolchain.buildPackages.binutils
           kani
+          pkgs.e2fsprogs
         ];
 
         basePackages = ciPackages ++ [
@@ -161,7 +162,6 @@
               pwndbg.packages.${system}.default
               pkgs.typos-lsp
               pkgs.dtc
-              pkgs.e2fsprogs
             ]
             ++ basePackages;
             shellHook = hook;


### PR DESCRIPTION
Replace self-hosted runner jobs with a single job on ubuntu-latest.
Use DeterminateSystems/nix-installer-action to install Nix and
magic-nix-cache-action to cache the Nix store in GitHub's cache.
All CI steps (build, fmt, clippy, unit-test, miri, system-test, kani)
run in one job via nix develop.

https://claude.ai/code/session_01F3VqKpatDujiKM9rmsajJo