### PR TITLE
Replace magic-nix-cache with cache-nix-action in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,11 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@main
 
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'rust-toolchain') }}
+          restore-prefixes-first-match: |
+            nix-${{ runner.os }}-
 
       - uses: nicknovitski/nix-develop@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/determinate-nix-action@v3
 
-      - uses: nix-community/cache-nix-action@v6
+      - uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'rust-toolchain') }}
           restore-prefixes-first-match: |


### PR DESCRIPTION
## Summary
Updated the CI workflow to use `nix-community/cache-nix-action` instead of `DeterminateSystems/magic-nix-cache-action` for improved Nix dependency caching.

## Changes
- Replaced `DeterminateSystems/magic-nix-cache-action@main` with `nix-community/cache-nix-action@v6`
- Added explicit cache configuration:
  - Primary cache key based on OS and hash of `flake.lock` and `rust-toolchain` files
  - Restore prefix pattern to match caches across different dependency versions

## Details
The new caching action provides more explicit control over cache keys and restoration behavior, allowing for better cache hit rates while maintaining compatibility across different build environments.

https://claude.ai/code/session_01AH682NJkoxvtZCKeLNfUbv