### PR TITLE
Implement Copy-on-Write for fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,7 @@ jobs:
       - uses: nix-community/cache-nix-action@v7
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'rust-toolchain') }}
-          restore-prefixes-first-match: |
-            nix-${{ runner.os }}-
-          save-always: true
+          restore-prefixes-all-matches: nix-${{ runner.os }}-
 
       - uses: nicknovitski/nix-develop@v1
         with:

--- a/doc/ai/MEMORY.md
+++ b/doc/ai/MEMORY.md
@@ -216,6 +216,40 @@ Core allocator in `sys/src/memory/heap.rs`, kernel-specific setup in `kernel/src
 
 Global allocator implementation using the page allocator.
 
+## Copy-on-Write (CoW) Fork
+
+**Files:** `kernel/src/processes/process.rs`, `kernel/src/interrupts/trap.rs`
+
+When a process forks, pages are shared instead of copied. Writable pages are marked read-only in both parent and child page tables. When either process writes to a shared page, the hardware generates a Store/AMO page fault (RISC-V cause 15), which triggers CoW resolution.
+
+### Data Structures
+
+```rust
+// Per-page CoW tracking on Process
+struct CowPageInfo {
+    phys_addr: PhysAddr,              // Physical address of shared page
+    original_perm: XWRMode,           // Permission before CoW downgrade
+    _backing: Arc<PinnedHeapPages>,   // Shared ownership (freed when last ref drops)
+}
+
+// Process fields for page tracking:
+// allocated_pages: BTreeMap<VirtAddr, PinnedHeapPages>  -- privately owned pages
+// cow_pages: BTreeMap<VirtAddr, CowPageInfo>            -- CoW-shared pages
+```
+
+### CoW Resolution Flow
+
+1. Store page fault → `handle_store_page_fault()` in `trap.rs`
+2. Looks up faulting VA in process's `cow_pages`
+3. Allocates new `PinnedHeapPages(1)`, copies 4K via `page_slice_at_phys()`
+4. Remaps PTE to new physical page with original writable permissions
+5. Moves entry from `cow_pages` to `allocated_pages`
+6. TLB flushed automatically on trap return (`sfence.vma` in `trap.S`)
+
+### Kernel Writes to CoW Pages
+
+`write_userspace_ptr/slice` (which take `&mut self`) resolve CoW for writable pages via `ensure_cow_resolved_for_write()` before the write validation, preventing EFAULT on read-only CoW pages.
+
 ## Memory Layout
 
 ### Kernel Space

--- a/doc/ai/MEMORY.md
+++ b/doc/ai/MEMORY.md
@@ -232,18 +232,18 @@ struct CowPageInfo {
     _backing: Arc<PinnedHeapPages>,   // Shared ownership (freed when last ref drops)
 }
 
-// Process fields for page tracking:
-// allocated_pages: BTreeMap<VirtAddr, PinnedHeapPages>  -- privately owned pages
-// cow_pages: BTreeMap<VirtAddr, CowPageInfo>            -- CoW-shared pages
+// All page mappings are in a single unified map:
+// mappings: BTreeMap<VirtAddr, Mapping>
+// where Mapping is Allocated(PinnedHeapPages) | Mmap(PinnedHeapPages) | Cow(CowPageInfo)
 ```
 
 ### CoW Resolution Flow
 
 1. Store page fault → `handle_store_page_fault()` in `trap.rs`
-2. Looks up faulting VA in process's `cow_pages`
+2. Looks up faulting VA in process's `mappings`, matches `Mapping::Cow`
 3. Allocates new `PinnedHeapPages(1)`, copies 4K via `page_slice_at_phys()`
 4. Remaps PTE to new physical page with original writable permissions
-5. Moves entry from `cow_pages` to `allocated_pages`
+5. Replaces `Mapping::Cow` entry with `Mapping::Allocated` in `mappings`
 6. TLB flushed automatically on trap return (`sfence.vma` in `trap.S`)
 
 ### Kernel Writes to CoW Pages

--- a/doc/ai/PROCESSES.md
+++ b/doc/ai/PROCESSES.md
@@ -16,9 +16,7 @@ Process management consists of:
 pub struct Process {
     name: Arc<String>,
     page_table: RootPageTableHolder,           // Virtual address space
-    allocated_pages: BTreeMap<VirtAddr, PinnedHeapPages>,  // Privately owned pages
-    mmap_allocations: BTreeMap<VirtAddr, PinnedHeapPages>, // mmap'd pages
-    cow_pages: BTreeMap<VirtAddr, CowPageInfo>,            // CoW-shared pages (see MEMORY.md)
+    mappings: BTreeMap<VirtAddr, Mapping>,      // All page mappings (see Mapping enum)
     free_mmap_address: VirtAddr,               // Next mmap VA (starts 0x2000000000)
     fd_table: Arc<Spinlock<FdTable>>,          // File descriptor table (shared across vfork)
     threads: BTreeMap<Tid, ThreadWeakRef>,
@@ -28,6 +26,12 @@ pub struct Process {
     brk: Brk,                                  // Heap break manager
     umask: u32,                                // File creation mask (default 0o022)
     cwd: String,                               // Current working directory (default "/")
+}
+
+pub enum Mapping {
+    Allocated(PinnedHeapPages),   // ELF-loaded, brk, resolved CoW pages
+    Mmap(PinnedHeapPages),        // mmap'd pages
+    Cow(CowPageInfo),             // CoW-shared pages (see MEMORY.md)
 }
 ```
 

--- a/doc/ai/PROCESSES.md
+++ b/doc/ai/PROCESSES.md
@@ -16,7 +16,9 @@ Process management consists of:
 pub struct Process {
     name: Arc<String>,
     page_table: RootPageTableHolder,           // Virtual address space
-    allocated_pages: Vec<PinnedHeapPages>,     // Physical memory
+    allocated_pages: BTreeMap<VirtAddr, PinnedHeapPages>,  // Privately owned pages
+    mmap_allocations: BTreeMap<VirtAddr, PinnedHeapPages>, // mmap'd pages
+    cow_pages: BTreeMap<VirtAddr, CowPageInfo>,            // CoW-shared pages (see MEMORY.md)
     free_mmap_address: VirtAddr,               // Next mmap VA (starts 0x2000000000)
     fd_table: Arc<Spinlock<FdTable>>,          // File descriptor table (shared across vfork)
     threads: BTreeMap<Tid, ThreadWeakRef>,
@@ -24,7 +26,6 @@ pub struct Process {
     pgid: Tid,                                 // Process group ID
     sid: Tid,                                  // Session ID
     brk: Brk,                                  // Heap break manager
-    vfork_parent: Option<ProcessRef>,          // Parent process ref during vfork
     umask: u32,                                // File creation mask (default 0o022)
     cwd: String,                               // Current working directory (default "/")
 }
@@ -41,9 +42,9 @@ impl Process {
 
     // Userspace pointer access
     fn read_userspace_ptr<T>(&self, ptr: &UserspacePtr<*const T>) -> Result<T, Errno>
-    fn write_userspace_ptr<T>(&self, ptr: &UserspacePtr<*mut T>, value: T) -> Result<(), Errno>
+    fn write_userspace_ptr<T>(&mut self, ptr: &UserspacePtr<*mut T>, value: T) -> Result<(), Errno>
     fn read_userspace_slice<T>(&self, ptr: &UserspacePtr<*const T>, len: usize) -> Result<Vec<T>, Errno>
-    fn write_userspace_slice<T>(&self, ptr: &UserspacePtr<*mut T>, data: &[T]) -> Result<(), Errno>
+    fn write_userspace_slice<T>(&mut self, ptr: &UserspacePtr<*mut T>, data: &[T]) -> Result<(), Errno>
 
     // File descriptor table
     fn fd_table(&self) -> SpinlockGuard<'_, FdTable>

--- a/kernel/src/interrupts/trap.rs
+++ b/kernel/src/interrupts/trap.rs
@@ -6,7 +6,11 @@ use crate::{
     processes::{task::Task, thread::ThreadState, timer, waker::ThreadWaker},
     syscalls::linux::LinuxSyscallHandler,
 };
-use arch::trap_cause::{InterruptCause, exception::ENVIRONMENT_CALL_FROM_U_MODE, interrupt};
+use arch::trap_cause::{
+    InterruptCause,
+    exception::{ENVIRONMENT_CALL_FROM_U_MODE, STORE_AMO_PAGE_FAULT},
+    interrupt,
+};
 use common::syscalls::trap_frame::{Register, TrapFrame};
 use core::{
     panic,
@@ -245,11 +249,21 @@ fn handle_unhandled_exception() {
     panic!("{}", message);
 }
 
+fn handle_store_page_fault() {
+    let stval = arch::cpu::read_stval();
+    let process = Cpu::with_scheduler(|s| s.get_current_process());
+    let resolved = process.with_lock(|mut p| p.resolve_cow_page(VirtAddr::new(stval)));
+    if !resolved {
+        handle_unhandled_exception();
+    }
+}
+
 fn handle_exception() {
     let cause = InterruptCause::from_scause();
     let code = cause.get_exception_code();
     match code {
         ENVIRONMENT_CALL_FROM_U_MODE => handle_syscall(),
+        STORE_AMO_PAGE_FAULT => handle_store_page_fault(),
         _ => handle_unhandled_exception(),
     }
 

--- a/kernel/src/io/uart.rs
+++ b/kernel/src/io/uart.rs
@@ -78,6 +78,7 @@ impl Uart {
     }
 }
 
+#[cfg(target_arch = "riscv64")]
 pub fn on_uart_interrupt() {
     let mut raw_bytes = crate::klibc::array_vec::ArrayVec::<u8, 64>::new();
     {

--- a/kernel/src/klibc/util.rs
+++ b/kernel/src/klibc/util.rs
@@ -134,6 +134,7 @@ impl<T, const N: usize> InBytes for [T; N] {
 mod kani_proofs {
     use super::*;
     use crate::memory::PAGE_SIZE;
+    use sys::klibc::util::{clear_bit, get_multiple_bits, set_bit, set_multiple_bits};
 
     #[kani::proof]
     fn align_up_is_at_least_input() {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -61,6 +61,7 @@ mod cpu;
 #[cfg(target_arch = "riscv64")]
 mod debugging;
 mod device_tree;
+#[cfg(target_arch = "riscv64")]
 mod drivers;
 mod fs;
 #[cfg(target_arch = "riscv64")]
@@ -69,6 +70,7 @@ mod io;
 mod klibc;
 mod logging;
 mod memory;
+#[cfg(target_arch = "riscv64")]
 mod net;
 #[cfg(all(target_arch = "riscv64", not(miri)))]
 pub mod panic;

--- a/kernel/src/memory/mod.rs
+++ b/kernel/src/memory/mod.rs
@@ -18,7 +18,7 @@ mod runtime_mappings;
 
 pub use sys::memory::{
     address::{PhysAddr, VirtAddr},
-    page::{PAGE_SIZE, Page, Pages, PagesAsSlice, PinnedHeapPages},
+    page::{PAGE_SIZE, Page, Pages, PagesAsSlice, PinnedHeapPages, page_slice_at_phys},
 };
 
 #[cfg(target_arch = "riscv64")]

--- a/kernel/src/memory/page_tables.rs
+++ b/kernel/src/memory/page_tables.rs
@@ -464,6 +464,16 @@ impl RootPageTableHolder {
         true
     }
 
+    #[expect(dead_code, reason = "will be used by CoW fork in next commit")]
+    pub fn remap_page(&mut self, va: VirtAddr, new_phys: PhysAddr, new_mode: XWRMode) {
+        assert!(va.is_page_aligned());
+        let pte = self
+            .walk_to_entry_mut(va)
+            .expect("remap_page: page not mapped");
+        pte.set_leaf_address(new_phys);
+        pte.set_xwr_mode(new_mode);
+    }
+
     pub fn get_userspace_permissions(&self, va: VirtAddr) -> Option<XWRMode> {
         self.walk_to_entry(va).map(|e| e.get_xwr_mode())
     }

--- a/kernel/src/memory/page_tables.rs
+++ b/kernel/src/memory/page_tables.rs
@@ -464,7 +464,6 @@ impl RootPageTableHolder {
         true
     }
 
-    #[expect(dead_code, reason = "will be used by CoW fork in next commit")]
     pub fn remap_page(&mut self, va: VirtAddr, new_phys: PhysAddr, new_mode: XWRMode) {
         assert!(va.is_page_aligned());
         let pte = self

--- a/kernel/src/processes/process.rs
+++ b/kernel/src/processes/process.rs
@@ -26,6 +26,12 @@ pub struct CowPageInfo {
     _backing: Arc<PinnedHeapPages>,
 }
 
+pub enum Mapping {
+    Allocated(PinnedHeapPages),
+    Mmap(PinnedHeapPages),
+    Cow(CowPageInfo),
+}
+
 pub struct ForkedAddressSpace {
     pub page_table: RootPageTableHolder,
     pub cow_pages: BTreeMap<VirtAddr, CowPageInfo>,
@@ -40,9 +46,7 @@ pub type ProcessRef = Arc<Spinlock<Process>>;
 pub struct Process {
     name: Arc<String>,
     page_table: RootPageTableHolder,
-    allocated_pages: BTreeMap<VirtAddr, PinnedHeapPages>,
-    mmap_allocations: BTreeMap<VirtAddr, PinnedHeapPages>,
-    cow_pages: BTreeMap<VirtAddr, CowPageInfo>,
+    mappings: BTreeMap<VirtAddr, Mapping>,
     free_mmap_address: VirtAddr,
     fd_table: Arc<Spinlock<FdTable>>,
     threads: BTreeMap<Tid, ThreadWeakRef>,
@@ -60,11 +64,11 @@ impl Debug for Process {
             f,
             "Process [
             Page Table: {:?},
-            Number of allocated page groups: {},
+            Number of mappings: {},
             Threads: {:?}
         ]",
             self.page_table,
-            self.allocated_pages.len(),
+            self.mappings.len(),
             self.threads,
         )
     }
@@ -80,12 +84,14 @@ impl Process {
         pgid: Tid,
         sid: Tid,
     ) -> Self {
+        let mappings = allocated_pages
+            .into_iter()
+            .map(|(va, pages)| (va, Mapping::Allocated(pages)))
+            .collect();
         Self {
             name,
             page_table,
-            allocated_pages,
-            mmap_allocations: BTreeMap::new(),
-            cow_pages: BTreeMap::new(),
+            mappings,
             free_mmap_address: VirtAddr::new(FREE_MMAP_START_ADDRESS),
             fd_table: Arc::new(Spinlock::new(FdTable::new())),
             threads: BTreeMap::new(),
@@ -164,7 +170,7 @@ impl Process {
             permission,
             "mmap".into(),
         );
-        self.mmap_allocations.insert(addr, pages);
+        self.mappings.insert(addr, Mapping::Mmap(pages));
         core::ptr::without_provenance_mut(addr.as_usize())
     }
 
@@ -179,15 +185,19 @@ impl Process {
             permission,
             "mmap".to_string(),
         );
-        self.mmap_allocations.insert(addr, pages);
+        self.mappings.insert(addr, Mapping::Mmap(pages));
         self.free_mmap_address += length;
         core::ptr::without_provenance_mut(addr.as_usize())
     }
 
     pub fn munmap_pages(&mut self, addr: VirtAddr, length: usize) -> Result<(), Errno> {
-        let pages = self.mmap_allocations.remove(&addr).ok_or(Errno::EINVAL)?;
+        let entry = self.mappings.remove(&addr).ok_or(Errno::EINVAL)?;
+        let Mapping::Mmap(pages) = entry else {
+            self.mappings.insert(addr, entry);
+            return Err(Errno::EINVAL);
+        };
         if pages.size() != length {
-            self.mmap_allocations.insert(addr, pages);
+            self.mappings.insert(addr, Mapping::Mmap(pages));
             return Err(Errno::EINVAL);
         }
         self.page_table.unmap_userspace(addr, length);
@@ -286,22 +296,19 @@ impl Process {
         let mut parent_cow = BTreeMap::new();
         let mut child_cow = BTreeMap::new();
 
-        let share_pages =
-            |pages_map: &mut BTreeMap<VirtAddr, PinnedHeapPages>,
-             child_pt: &mut RootPageTableHolder,
-             parent_pt: &mut RootPageTableHolder,
-             parent_cow: &mut BTreeMap<VirtAddr, CowPageInfo>,
-             child_cow: &mut BTreeMap<VirtAddr, CowPageInfo>| {
-                for (va, pages) in core::mem::take(pages_map) {
+        for (va, mapping) in core::mem::take(&mut self.mappings) {
+            match mapping {
+                Mapping::Allocated(pages) | Mapping::Mmap(pages) => {
                     let backing = Arc::new(pages);
                     for i in 0..backing.len() {
                         let page_va = va + i * PAGE_SIZE;
-                        let Some(perm) = parent_pt.get_userspace_permissions(page_va) else {
+                        let Some(perm) = self.page_table.get_userspace_permissions(page_va) else {
                             continue;
                         };
                         let phys_addr = PhysAddr::new(backing.addr() + i * PAGE_SIZE);
                         let child_perm = if perm.is_writable() {
-                            parent_pt.remap_page(page_va, phys_addr, perm.as_readonly());
+                            self.page_table
+                                .remap_page(page_va, phys_addr, perm.as_readonly());
                             perm.as_readonly()
                         } else {
                             perm
@@ -313,14 +320,11 @@ impl Process {
                             child_perm,
                             "fork-cow".into(),
                         );
-                        parent_cow.insert(
-                            page_va,
-                            CowPageInfo {
-                                phys_addr,
-                                original_perm: perm,
-                                _backing: Arc::clone(&backing),
-                            },
-                        );
+                        let cow_info = CowPageInfo {
+                            phys_addr,
+                            original_perm: perm,
+                            _backing: Arc::clone(&backing),
+                        };
                         child_cow.insert(
                             page_va,
                             CowPageInfo {
@@ -329,52 +333,38 @@ impl Process {
                                 _backing: Arc::clone(&backing),
                             },
                         );
+                        parent_cow.insert(page_va, cow_info);
                     }
                 }
-            };
-
-        share_pages(
-            &mut self.allocated_pages,
-            &mut child_pt,
-            &mut self.page_table,
-            &mut parent_cow,
-            &mut child_cow,
-        );
-        share_pages(
-            &mut self.mmap_allocations,
-            &mut child_pt,
-            &mut self.page_table,
-            &mut parent_cow,
-            &mut child_cow,
-        );
-
-        // Also share pages that are already CoW from a previous fork.
-        // For writable CoW pages that haven't been resolved yet, they're
-        // already read-only in the parent's page table. For non-writable
-        // pages, permissions are unchanged. Just clone the Arc for the child.
-        for (&page_va, cow_info) in &self.cow_pages {
-            let current_perm = self
-                .page_table
-                .get_userspace_permissions(page_va)
-                .expect("cow_pages entry must be mapped");
-            child_pt.map_userspace(
-                page_va,
-                cow_info.phys_addr,
-                PAGE_SIZE,
-                current_perm,
-                "fork-cow".into(),
-            );
-            child_cow.insert(
-                page_va,
-                CowPageInfo {
-                    phys_addr: cow_info.phys_addr,
-                    original_perm: cow_info.original_perm,
-                    _backing: Arc::clone(&cow_info._backing),
-                },
-            );
+                Mapping::Cow(cow_info) => {
+                    let current_perm = self
+                        .page_table
+                        .get_userspace_permissions(va)
+                        .expect("cow_pages entry must be mapped");
+                    child_pt.map_userspace(
+                        va,
+                        cow_info.phys_addr,
+                        PAGE_SIZE,
+                        current_perm,
+                        "fork-cow".into(),
+                    );
+                    child_cow.insert(
+                        va,
+                        CowPageInfo {
+                            phys_addr: cow_info.phys_addr,
+                            original_perm: cow_info.original_perm,
+                            _backing: Arc::clone(&cow_info._backing),
+                        },
+                    );
+                    parent_cow.insert(va, cow_info);
+                }
+            }
         }
 
-        self.cow_pages.append(&mut parent_cow);
+        self.mappings = parent_cow
+            .into_iter()
+            .map(|(va, info)| (va, Mapping::Cow(info)))
+            .collect();
 
         ForkedAddressSpace {
             page_table: child_pt,
@@ -389,7 +379,10 @@ impl Process {
         cow_pages: BTreeMap<VirtAddr, CowPageInfo>,
         free_mmap_address: VirtAddr,
     ) {
-        self.cow_pages = cow_pages;
+        self.mappings = cow_pages
+            .into_iter()
+            .map(|(va, info)| (va, Mapping::Cow(info)))
+            .collect();
         self.free_mmap_address = free_mmap_address;
     }
 
@@ -397,7 +390,11 @@ impl Process {
         use crate::memory::page_slice_at_phys;
 
         let page_va = VirtAddr::new(faulting_va.as_usize() & !(PAGE_SIZE - 1));
-        let Some(cow_info) = self.cow_pages.remove(&page_va) else {
+        let Some(mapping) = self.mappings.remove(&page_va) else {
+            return false;
+        };
+        let Mapping::Cow(cow_info) = mapping else {
+            self.mappings.insert(page_va, mapping);
             return false;
         };
 
@@ -407,12 +404,12 @@ impl Process {
         let new_phys = PhysAddr::new(new_page.addr());
         self.page_table
             .remap_page(page_va, new_phys, cow_info.original_perm);
-        self.allocated_pages.insert(page_va, new_page);
+        self.mappings.insert(page_va, Mapping::Allocated(new_page));
         true
     }
 
     fn ensure_cow_resolved_for_write(&mut self, addr: usize, len: usize) {
-        if len == 0 || self.cow_pages.is_empty() {
+        if len == 0 {
             return;
         }
         let start_page = addr & !(PAGE_SIZE - 1);
@@ -420,11 +417,11 @@ impl Process {
         let num_pages = (end_page - start_page) / PAGE_SIZE + 1;
         for i in 0..num_pages {
             let va = VirtAddr::new(start_page + i * PAGE_SIZE);
-            if self
-                .cow_pages
-                .get(&va)
-                .is_some_and(|c| c.original_perm.is_writable())
-            {
+            let is_writable_cow = matches!(
+                self.mappings.get(&va),
+                Some(Mapping::Cow(c)) if c.original_perm.is_writable()
+            );
+            if is_writable_cow {
                 self.resolve_cow_page(va);
             }
         }
@@ -444,8 +441,9 @@ impl core::fmt::Display for Process {
 impl Drop for Process {
     fn drop(&mut self) {
         debug!(
-            "Drop process (MAIN_TID: {}) (Allocated pages: {:?})",
-            self.main_tid, self.allocated_pages
+            "Drop process (MAIN_TID: {}) (Mappings: {})",
+            self.main_tid,
+            self.mappings.len()
         );
     }
 }

--- a/kernel/src/processes/process.rs
+++ b/kernel/src/processes/process.rs
@@ -119,10 +119,11 @@ impl Process {
     }
 
     pub fn write_userspace_slice<T: Copy>(
-        &self,
+        &mut self,
         ptr: &UserspacePtr<*mut T>,
         data: &[T],
     ) -> Result<(), Errno> {
+        self.ensure_cow_resolved_for_write(ptr.get() as usize, core::mem::size_of_val(data));
         let validated =
             ValidatedPtr::<T>::from_userspace(ptr.get(), data.len(), self.get_page_table())?;
         validated.write_slice(data);
@@ -135,10 +136,11 @@ impl Process {
     }
 
     pub fn write_userspace_ptr<T>(
-        &self,
+        &mut self,
         ptr: &UserspacePtr<*mut T>,
         value: T,
     ) -> Result<(), Errno> {
+        self.ensure_cow_resolved_for_write(ptr.get() as usize, core::mem::size_of::<T>());
         let validated = ValidatedPtr::<T>::from_userspace(ptr.get(), 1, self.get_page_table())?;
         validated.write(value);
         Ok(())
@@ -407,6 +409,25 @@ impl Process {
             .remap_page(page_va, new_phys, cow_info.original_perm);
         self.allocated_pages.insert(page_va, new_page);
         true
+    }
+
+    fn ensure_cow_resolved_for_write(&mut self, addr: usize, len: usize) {
+        if len == 0 || self.cow_pages.is_empty() {
+            return;
+        }
+        let start_page = addr & !(PAGE_SIZE - 1);
+        let end_page = (addr + len - 1) & !(PAGE_SIZE - 1);
+        let num_pages = (end_page - start_page) / PAGE_SIZE + 1;
+        for i in 0..num_pages {
+            let va = VirtAddr::new(start_page + i * PAGE_SIZE);
+            if self
+                .cow_pages
+                .get(&va)
+                .is_some_and(|c| c.original_perm.is_writable())
+            {
+                self.resolve_cow_page(va);
+            }
+        }
     }
 }
 

--- a/kernel/src/processes/process.rs
+++ b/kernel/src/processes/process.rs
@@ -20,10 +20,15 @@ use sys::klibc::validated_ptr::ValidatedPtr;
 
 pub const POWERSAVE_TID: Tid = Tid::new(0);
 
+pub struct CowPageInfo {
+    pub phys_addr: PhysAddr,
+    pub original_perm: XWRMode,
+    _backing: Arc<PinnedHeapPages>,
+}
+
 pub struct ForkedAddressSpace {
     pub page_table: RootPageTableHolder,
-    pub allocated_pages: BTreeMap<VirtAddr, PinnedHeapPages>,
-    pub mmap_allocations: BTreeMap<VirtAddr, PinnedHeapPages>,
+    pub cow_pages: BTreeMap<VirtAddr, CowPageInfo>,
     pub brk: Brk,
     pub free_mmap_address: VirtAddr,
 }
@@ -37,6 +42,7 @@ pub struct Process {
     page_table: RootPageTableHolder,
     allocated_pages: BTreeMap<VirtAddr, PinnedHeapPages>,
     mmap_allocations: BTreeMap<VirtAddr, PinnedHeapPages>,
+    cow_pages: BTreeMap<VirtAddr, CowPageInfo>,
     free_mmap_address: VirtAddr,
     fd_table: Arc<Spinlock<FdTable>>,
     threads: BTreeMap<Tid, ThreadWeakRef>,
@@ -79,6 +85,7 @@ impl Process {
             page_table,
             allocated_pages,
             mmap_allocations: BTreeMap::new(),
+            cow_pages: BTreeMap::new(),
             free_mmap_address: VirtAddr::new(FREE_MMAP_START_ADDRESS),
             fd_table: Arc::new(Spinlock::new(FdTable::new())),
             threads: BTreeMap::new(),
@@ -261,7 +268,7 @@ impl Process {
         self.threads.keys().copied().collect()
     }
 
-    pub fn fork_address_space(&self) -> ForkedAddressSpace {
+    pub fn fork_address_space(&mut self) -> ForkedAddressSpace {
         use super::signal;
 
         let mut child_pt = RootPageTableHolder::new_with_kernel_mapping(&[]);
@@ -274,55 +281,132 @@ impl Process {
             "Signal trampoline".into(),
         );
 
-        let copy_pages = |pages_map: &BTreeMap<VirtAddr, PinnedHeapPages>,
-                          pt: &mut RootPageTableHolder,
-                          parent_pt: &RootPageTableHolder|
-         -> BTreeMap<VirtAddr, PinnedHeapPages> {
-            let mut child_map = BTreeMap::new();
-            for (&va, parent_pages) in pages_map {
-                let mut child_pages = PinnedHeapPages::new(parent_pages.len());
-                for (dst, src) in child_pages.iter_mut().zip(parent_pages.iter()) {
-                    let dst_slice: &mut [u8] = &mut **dst;
-                    let src_slice: &[u8] = &**src;
-                    dst_slice.copy_from_slice(src_slice);
-                }
-                for i in 0..parent_pages.len() {
-                    let page_va = va + i * PAGE_SIZE;
-                    let Some(perm) = parent_pt.get_userspace_permissions(page_va) else {
-                        continue;
-                    };
-                    pt.map_userspace(
-                        page_va,
-                        PhysAddr::new(child_pages.addr() + i * PAGE_SIZE),
-                        PAGE_SIZE,
-                        perm,
-                        "fork".into(),
-                    );
-                }
-                child_map.insert(va, child_pages);
-            }
-            child_map
-        };
+        let mut parent_cow = BTreeMap::new();
+        let mut child_cow = BTreeMap::new();
 
-        let allocated_pages = copy_pages(&self.allocated_pages, &mut child_pt, &self.page_table);
-        let mmap_allocations = copy_pages(&self.mmap_allocations, &mut child_pt, &self.page_table);
+        let share_pages =
+            |pages_map: &mut BTreeMap<VirtAddr, PinnedHeapPages>,
+             child_pt: &mut RootPageTableHolder,
+             parent_pt: &mut RootPageTableHolder,
+             parent_cow: &mut BTreeMap<VirtAddr, CowPageInfo>,
+             child_cow: &mut BTreeMap<VirtAddr, CowPageInfo>| {
+                for (va, pages) in core::mem::take(pages_map) {
+                    let backing = Arc::new(pages);
+                    for i in 0..backing.len() {
+                        let page_va = va + i * PAGE_SIZE;
+                        let Some(perm) = parent_pt.get_userspace_permissions(page_va) else {
+                            continue;
+                        };
+                        let phys_addr = PhysAddr::new(backing.addr() + i * PAGE_SIZE);
+                        let child_perm = if perm.is_writable() {
+                            parent_pt.remap_page(page_va, phys_addr, perm.as_readonly());
+                            perm.as_readonly()
+                        } else {
+                            perm
+                        };
+                        child_pt.map_userspace(
+                            page_va,
+                            phys_addr,
+                            PAGE_SIZE,
+                            child_perm,
+                            "fork-cow".into(),
+                        );
+                        parent_cow.insert(
+                            page_va,
+                            CowPageInfo {
+                                phys_addr,
+                                original_perm: perm,
+                                _backing: Arc::clone(&backing),
+                            },
+                        );
+                        child_cow.insert(
+                            page_va,
+                            CowPageInfo {
+                                phys_addr,
+                                original_perm: perm,
+                                _backing: Arc::clone(&backing),
+                            },
+                        );
+                    }
+                }
+            };
+
+        share_pages(
+            &mut self.allocated_pages,
+            &mut child_pt,
+            &mut self.page_table,
+            &mut parent_cow,
+            &mut child_cow,
+        );
+        share_pages(
+            &mut self.mmap_allocations,
+            &mut child_pt,
+            &mut self.page_table,
+            &mut parent_cow,
+            &mut child_cow,
+        );
+
+        // Also share pages that are already CoW from a previous fork.
+        // For writable CoW pages that haven't been resolved yet, they're
+        // already read-only in the parent's page table. For non-writable
+        // pages, permissions are unchanged. Just clone the Arc for the child.
+        for (&page_va, cow_info) in &self.cow_pages {
+            let current_perm = self
+                .page_table
+                .get_userspace_permissions(page_va)
+                .expect("cow_pages entry must be mapped");
+            child_pt.map_userspace(
+                page_va,
+                cow_info.phys_addr,
+                PAGE_SIZE,
+                current_perm,
+                "fork-cow".into(),
+            );
+            child_cow.insert(
+                page_va,
+                CowPageInfo {
+                    phys_addr: cow_info.phys_addr,
+                    original_perm: cow_info.original_perm,
+                    _backing: Arc::clone(&cow_info._backing),
+                },
+            );
+        }
+
+        self.cow_pages.append(&mut parent_cow);
 
         ForkedAddressSpace {
             page_table: child_pt,
-            allocated_pages,
-            mmap_allocations,
+            cow_pages: child_cow,
             brk: self.brk.clone(),
             free_mmap_address: self.free_mmap_address,
         }
     }
 
-    pub fn set_mmap_state(
+    pub fn set_fork_state(
         &mut self,
-        mmap_allocations: BTreeMap<VirtAddr, PinnedHeapPages>,
+        cow_pages: BTreeMap<VirtAddr, CowPageInfo>,
         free_mmap_address: VirtAddr,
     ) {
-        self.mmap_allocations = mmap_allocations;
+        self.cow_pages = cow_pages;
         self.free_mmap_address = free_mmap_address;
+    }
+
+    pub fn resolve_cow_page(&mut self, faulting_va: VirtAddr) -> bool {
+        use crate::memory::page_slice_at_phys;
+
+        let page_va = VirtAddr::new(faulting_va.as_usize() & !(PAGE_SIZE - 1));
+        let Some(cow_info) = self.cow_pages.remove(&page_va) else {
+            return false;
+        };
+
+        let mut new_page = PinnedHeapPages::new(1);
+        let src = page_slice_at_phys(cow_info.phys_addr);
+        new_page[0].copy_from_slice(src);
+        let new_phys = PhysAddr::new(new_page.addr());
+        self.page_table
+            .remap_page(page_va, new_phys, cow_info.original_perm);
+        self.allocated_pages.insert(page_va, new_page);
+        true
     }
 }
 

--- a/kernel/src/processes/process_table.rs
+++ b/kernel/src/processes/process_table.rs
@@ -308,7 +308,7 @@ impl ProcessTable {
                 let futex_addr = if let Some(clear_child_tid) = t.get_clear_child_tid() {
                     let process = t.process();
                     let addr = clear_child_tid.get() as usize;
-                    let _ = clear_child_tid.write_with_process_lock(&process.lock(), 0);
+                    let _ = clear_child_tid.write_with_process_lock(&mut process.lock(), 0);
                     Some(addr)
                 } else {
                     None

--- a/kernel/src/processes/userspace_ptr.rs
+++ b/kernel/src/processes/userspace_ptr.rs
@@ -24,7 +24,7 @@ impl<PTR: Pointer> UserspacePtr<PTR> {
 impl<T> UserspacePtr<*mut T> {
     pub fn write_with_process_lock(
         &self,
-        process_lock: &SpinlockGuard<'_, Process>,
+        process_lock: &mut SpinlockGuard<'_, Process>,
         value: T,
     ) -> Result<(), Errno> {
         process_lock.write_userspace_ptr(self, value)

--- a/kernel/src/syscalls/linux_validator.rs
+++ b/kernel/src/syscalls/linux_validator.rs
@@ -63,7 +63,7 @@ impl<T: Copy> LinuxUserspaceArg<*mut T> {
     }
     pub fn write_slice(&self, values: &[T]) -> Result<(), Errno> {
         self.process
-            .with_lock(|p| p.write_userspace_slice(&self.into(), values))?;
+            .with_lock(|mut p| p.write_userspace_slice(&self.into(), values))?;
         Ok(())
     }
 }
@@ -74,7 +74,7 @@ impl<T: Clone> LinuxUserspaceArg<Option<*mut T>> {
             return Ok(None);
         }
         self.process
-            .with_lock(|p| p.write_userspace_ptr(&self.into(), value))?;
+            .with_lock(|mut p| p.write_userspace_ptr(&self.into(), value))?;
         Ok(Some(()))
     }
 }

--- a/kernel/src/syscalls/process_ops.rs
+++ b/kernel/src/syscalls/process_ops.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, sync::Arc};
+use alloc::{collections::BTreeMap, string::String, sync::Arc};
 use core::ffi::{c_int, c_ulong};
 use headers::{
     errno::Errno,
@@ -39,12 +39,12 @@ impl LinuxSyscallHandler {
 
         let child_tid = get_next_tid();
 
-        let forked = parent_process.with_lock(|p| p.fork_address_space());
+        let forked = parent_process.with_lock(|mut p| p.fork_address_space());
 
         let child_process = Arc::new(Spinlock::new(Process::new(
             child_name.clone(),
             forked.page_table,
-            forked.allocated_pages,
+            BTreeMap::new(),
             forked.brk,
             child_tid,
             parent_pgid,
@@ -58,7 +58,7 @@ impl LinuxSyscallHandler {
             child.set_fd_table(parent_fd_table);
             child.set_cwd(parent_cwd);
             child.set_umask(parent_umask);
-            child.set_mmap_state(forked.mmap_allocations, forked.free_mmap_address);
+            child.set_fork_state(forked.cow_pages, forked.free_mmap_address);
         }
 
         let mut child_regs = parent_regs;

--- a/sys/src/memory/mod.rs
+++ b/sys/src/memory/mod.rs
@@ -5,7 +5,7 @@ pub mod page_allocator;
 pub mod page_table;
 
 pub use address::{PhysAddr, VirtAddr};
-pub use page::{PAGE_SIZE, Page, Pages, PagesAsSlice, PinnedHeapPages};
+pub use page::{PAGE_SIZE, Page, Pages, PagesAsSlice, PinnedHeapPages, page_slice_at_phys};
 
 use core::mem::MaybeUninit;
 

--- a/sys/src/memory/page.rs
+++ b/sys/src/memory/page.rs
@@ -78,6 +78,16 @@ impl PagesAsSlice for [Page] {
     }
 }
 
+/// Returns a reference to the 4K page at the given physical address.
+/// Works because the kernel identity-maps all physical memory.
+pub fn page_slice_at_phys(addr: super::PhysAddr) -> &'static [u8; PAGE_SIZE] {
+    assert!(addr.is_page_aligned());
+    // SAFETY: The kernel identity-maps all physical RAM, so the physical
+    // address equals the virtual address. The returned reference is valid
+    // for the lifetime of the kernel (physical pages are never moved).
+    unsafe { &*(addr.as_usize() as *const [u8; PAGE_SIZE]) }
+}
+
 #[derive(Debug)]
 pub struct PinnedHeapPages {
     allocation: Box<[Page]>,

--- a/sys/src/memory/page_table.rs
+++ b/sys/src/memory/page_table.rs
@@ -30,6 +30,18 @@ impl From<u8> for XWRMode {
 }
 
 impl XWRMode {
+    pub fn is_writable(self) -> bool {
+        matches!(self, Self::ReadWrite | Self::ReadWriteExecute)
+    }
+
+    pub fn as_readonly(self) -> Self {
+        match self {
+            Self::ReadWrite => Self::ReadOnly,
+            Self::ReadWriteExecute => Self::ReadExecute,
+            other => other,
+        }
+    }
+
     pub fn from_prot(prot: u32) -> Result<Self, headers::errno::Errno> {
         use headers::syscall_types::{PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE};
         match prot {

--- a/system-tests/src/tests/fork.rs
+++ b/system-tests/src/tests/fork.rs
@@ -14,3 +14,21 @@ async fn fork_basic() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn fork_cow_isolation() -> anyhow::Result<()> {
+    let mut solaya = QemuInstance::start().await?;
+
+    let output = solaya.run_prog("cow-test").await?;
+
+    assert!(
+        output.contains("child: value=99"),
+        "child should see modified value: {output}"
+    );
+    assert!(
+        output.contains("parent: value=42"),
+        "parent should see original value: {output}"
+    );
+
+    Ok(())
+}

--- a/userspace/src/bin/cow-test.rs
+++ b/userspace/src/bin/cow-test.rs
@@ -1,0 +1,23 @@
+unsafe extern "C" {
+    fn fork() -> i32;
+    fn waitpid(pid: i32, status: *mut i32, options: i32) -> i32;
+}
+
+fn main() {
+    let mut stack_value = 42;
+    let pid = unsafe { fork() };
+    if pid == 0 {
+        // Child: modify the variable (triggers CoW)
+        stack_value = 99;
+        assert_eq!(stack_value, 99);
+        println!("child: value={stack_value}");
+    } else if pid > 0 {
+        let mut status: i32 = 0;
+        unsafe { waitpid(pid, &mut status, 0) };
+        // Parent: value must be unchanged (CoW isolation)
+        assert_eq!(stack_value, 42);
+        println!("parent: value={stack_value}");
+    } else {
+        println!("fork failed");
+    }
+}

--- a/userspace/src/bin/cow-test.rs
+++ b/userspace/src/bin/cow-test.rs
@@ -1,22 +1,27 @@
+use core::ptr::{read_volatile, write_volatile};
+
 unsafe extern "C" {
     fn fork() -> i32;
     fn waitpid(pid: i32, status: *mut i32, options: i32) -> i32;
 }
 
 fn main() {
-    let mut stack_value = 42;
+    // Use Box to guarantee the value lives on the heap (a CoW page).
+    // Use volatile reads/writes to prevent the compiler from keeping
+    // the value in a register and optimizing away the memory access.
+    let mut value = Box::new(42i32);
     let pid = unsafe { fork() };
     if pid == 0 {
-        // Child: modify the variable (triggers CoW)
-        stack_value = 99;
-        assert_eq!(stack_value, 99);
-        println!("child: value={stack_value}");
+        unsafe { write_volatile(&mut *value, 99) };
+        let v = unsafe { read_volatile(&*value) };
+        assert_eq!(v, 99);
+        println!("child: value={v}");
     } else if pid > 0 {
         let mut status: i32 = 0;
         unsafe { waitpid(pid, &mut status, 0) };
-        // Parent: value must be unchanged (CoW isolation)
-        assert_eq!(stack_value, 42);
-        println!("parent: value={stack_value}");
+        let v = unsafe { read_volatile(&*value) };
+        assert_eq!(v, 42);
+        println!("parent: value={v}");
     } else {
         println!("fork failed");
     }


### PR DESCRIPTION
## Summary
- Fork now shares physical pages between parent and child instead of copying them. Writable pages are marked read-only; writes trigger Store/AMO page faults that resolve CoW by allocating a fresh page and copying on demand.
- Per-page `CowPageInfo` with `Arc<PinnedHeapPages>` provides shared ownership — pages are freed automatically when the last reference drops.
- Kernel-side `write_userspace_ptr/slice` resolve CoW before writing, preventing EFAULT on read-only CoW pages during syscalls like `read()`.

## Test plan
- [x] All 60 system tests pass (59 existing + 1 new `fork_cow_isolation`)
- [x] New `cow-test` userspace program verifies parent/child data isolation after fork+write
- [x] Clippy clean, no warnings
- [x] `just stress-system-test` for stability

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)